### PR TITLE
changed matplotlib to inline for cross-correlation and NIRcam noteboo…

### DIFF
--- a/notebooks/redshift_crosscorr/redshift_with_crosscorr.ipynb
+++ b/notebooks/redshift_crosscorr/redshift_with_crosscorr.ipynb
@@ -28,9 +28,6 @@
     "import os\n",
     "import numpy as np\n",
     "\n",
-    "%matplotlib notebook\n",
-    "import matplotlib.pyplot as pl\n",
-    "\n",
     "from scipy.signal.windows import tukey\n",
     "import astropy\n",
     "import astropy.units as u\n",
@@ -61,6 +58,39 @@
     "print(\"Numpy:  1.18.1\")\n",
     "print(\"Astropy:  4.0\")\n",
     "print(\"Specutils:  1.0\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Matplotlib setup for plotting\n",
+    "There are two versions\n",
+    " - `notebook` -- gives interactive plots, but makes the overall notebook a bit harder to scroll\n",
+    " - `inline` -- gives non-interactive plots for better overall scrolling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as pl\n",
+    "import matplotlib as mpl\n",
+    "\n",
+    "# Use this version for non-interactive plots (easier scrolling of the notebook)\n",
+    "%matplotlib inline\n",
+    "\n",
+    "# Use this version if you want interactive plots\n",
+    "# %matplotlib notebook\n",
+    "\n",
+    "# These gymnastics are needed to make the sizes of the figures\n",
+    "# be the same in both the inline and notebook versions\n",
+    "%config InlineBackend.print_figure_kwargs = {'bbox_inches': None}\n",
+    "\n",
+    "mpl.rcParams['savefig.dpi'] = 80\n",
+    "mpl.rcParams['figure.dpi'] = 80"
    ]
   },
   {
@@ -664,13 +694,6 @@
     "z_err = (z - z_ref) / z_ref * 100.\n",
     "print(\"Error in the derived redshift: \", z_err, \"%\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -689,7 +712,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Notebooks weren't rendering online. I changed matplotlib from `notebook` to `inline` for default, with a commented out inline and instructions to the user for changing it. Plus some ugly magic to keep the plot sizes the same in both versions. This follows what the background-subtraction notebook was doing.