### PR TITLE
add transpose to use of CircularAperture

### DIFF
--- a/notebooks/MRS_Mstar_analysis/JWST_Mstar_dataAnalysis_usecase.ipynb
+++ b/notebooks/MRS_Mstar_analysis/JWST_Mstar_dataAnalysis_usecase.ipynb
@@ -727,7 +727,7 @@
     "    else:\n",
     "        positions_pix = (sources['xcentroid'], sources['ycentroid'])\n",
     "\n",
-    "    apertures = CircularAperture(positions_pix, r = 2.)   # Aperture radius = 2 pixels\n",
+    "    apertures = CircularAperture(np.array(positions_pix).T, r = 2.)   # Aperture radius = 2 pixels\n",
     "    \n",
     "    #-----------------------------------------------------\n",
     "    # As a check to make sure all obvious point sources have been identified\n",


### PR DESCRIPTION
This fixes a failure that looks to me to be due to a transpose issue.  I'm not sure why this ever worked - maybe  an earlier version of photutils behaved differently?  But hopefully the CI will pass on this one now...