### PR TITLE
Attempted to resolve transit notebook build error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,7 @@ pyregion
 pysynphot
 pyyaml
 scikit-image
+scikit-learn
 scipy
 seaborn 
 shapely


### PR DESCRIPTION
`transit_spectroscopy_notebook/Exoplanet_Transmission_Spectra_JWST.ipynb` seems like it just needs a package that wasn't included in the common `requirements.txt` file. I am able to run it locally with no errors after adding `scikit-learn` to the requirements and reinstalling the environment.