### PR TITLE
Update to add pre-requirements to allow build of CANDID

### DIFF
--- a/.github/workflows/ci_builder.yml
+++ b/.github/workflows/ci_builder.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         sudo apt-get install python3-pip
-        pip install cython
+        pip install -r pre-requirements.txt
         pip install -r requirements.txt
         #        pip install git+git://github.com/executablebookproject/cli.git
         pip install ghp-import

--- a/.github/workflows/ci_buildondemand.yml
+++ b/.github/workflows/ci_buildondemand.yml
@@ -41,8 +41,7 @@ jobs:
       - name: Install dependencies
         run: |
           #conda env update --file CIenvironment.yml --name base
-          pip install cython
-          pip install numpy
+          pip install -r pre-requirements.txt
           pip install radvel
           #pip install -r requirements.txt --use-deprecated=legacy-resolver
           pip install -r requirements.txt

--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install dependencies
         run: |
           #conda env update --file CIenvironment.yml --name base
-          pip install cython
+          pip install -r pre-requirements.txt
           pip install -r requirements.txt
           pip install pytest
           pip install nbval

--- a/.github/workflows/ci_ondemand_html.yml
+++ b/.github/workflows/ci_ondemand_html.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         sudo apt-get install python3-pip
-        pip install cython
+        pip install -r pre-requirements.txt
         pip install -r requirements.txt
         #        pip install git+git://github.com/executablebookproject/cli.git
         pip install ghp-import

--- a/.github/workflows/ci_validation.yml
+++ b/.github/workflows/ci_validation.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         #conda env update --file CIenvironment.yml --name base
-        pip install cython
+        pip install -r pre-requirements.txt
         pip install -r requirements.txt
         pip install pytest
         pip install nbval

--- a/pre-requirements.txt
+++ b/pre-requirements.txt
@@ -1,0 +1,2 @@
+numpy
+cython

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,5 +65,5 @@ jwst_gtvt
 mirage
 webbpsf @ git+https://github.com/spacetelescope/webbpsf@bb8706e6ebf3f8dc842bd37830449182854c0b11
 stsynphot
-
+git+https://github.com/amerand/CANDID.git
 


### PR DESCRIPTION
CANDID requires cython and numpy to be pre-installed before installation via the requirements.txt file.  A new pre-requirements.txt with these prerequisites has been added along side the global requirements file (which now contains candid).   Workflows have been updated to pip install these files in order on worker CI nodes.

A user would pip install the pre-requirements.txt file first, then install requirements.txt from the root of the repository.

This will change when we get final consensus requirements management.