### PR TITLE
Avoid linking to PR in PEP8 commit messages

### DIFF
--- a/.github/workflows/notebook-pep8-check.yml
+++ b/.github/workflows/notebook-pep8-check.yml
@@ -184,7 +184,7 @@ jobs:
 
           # list changed notebooks in commit message; push the changes
           git_diff_new=($(git diff --name-only --diff-filter=M *ipynb))
-          git commit -m "[BOT] Left PEP8 feedback on PR #${{ github.event.number }}'s notebooks" -m "Files: $(printf '%s\n' $git_diff_new)"
+          git commit -m "[BOT] Left PEP8 feedback on PR ${{ github.event.number }}'s notebooks" -m "Files: $(printf '%s\n' $git_diff_new)"
           # (is tagging the PR for the best here?)
 
           git push origin "HEAD:${{ github.event.pull_request.head.ref }}"


### PR DESCRIPTION
This keeps technical review pull requests from being updated every time a matching PEP8 commit is referenced.