### PR TITLE
Switch to using Video display in sky bkg notebook

### DIFF
--- a/notebooks/background_estimation_imaging/Imaging_Sky_Background_Estimation.ipynb
+++ b/notebooks/background_estimation_imaging/Imaging_Sky_Background_Estimation.ipynb
@@ -68,7 +68,7 @@
     "from scipy.ndimage.filters import median_filter\n",
     "from astropy.modeling import models, fitting\n",
     "from astropy.nddata.blocks import block_reduce\n",
-    "from IPython.display import HTML\n",
+    "from IPython.display import Video\n",
     "from jdaviz import Imviz"
    ]
   },
@@ -368,7 +368,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Video1:\n",
+    "## Video:\n",
     "\n",
     "Link two images in different windows by pixel and manipulate image."
    ]
@@ -380,7 +380,7 @@
    "outputs": [],
    "source": [
     "# Video showing how to link two images in pixel space using plugin\n",
-    "HTML('<iframe width=\"700\" height=\"500\" src=\"https://data.science.stsci.edu/redirect/JWST/jwst-data_analysis_tools/Background_Estimation/imviz_demo_1.mov\" frameborder=\"0\" allowfullscreen></iframe>')"
+    "Video(url='https://data.science.stsci.edu/redirect/JWST/jwst-data_analysis_tools/Background_Estimation/imviz_demo_1.mov', width=700, height=500)"
    ]
   },
   {


### PR DESCRIPTION
While looking through some notebooks I happened upon this one that uses iframes to display video.  Jupyter has a `Video` embedding that works better for me locally at least in Jupyter Lab - I actually thought this use of iframes didn't even work anymore? :shrug: 

(I also renamed "Video1" to "Video" since there's only one anyway)