### PR TITLE
Fixed casing on argument to set_colormap.

### DIFF
--- a/notebooks/background_estimation_imaging/Imaging_Sky_Background_Estimation.ipynb
+++ b/notebooks/background_estimation_imaging/Imaging_Sky_Background_Estimation.ipynb
@@ -271,7 +271,7 @@
    "outputs": [],
    "source": [
     "viewer.colormap_options\n",
-    "viewer.set_colormap('viridis')"
+    "viewer.set_colormap('Viridis')"
    ]
   },
   {
@@ -337,7 +337,7 @@
     "viewer.stretch_options\n",
     "viewer.stretch = 'sqrt'\n",
     "viewer.colormap_options\n",
-    "viewer.set_colormap('viridis')"
+    "viewer.set_colormap('Viridis')"
    ]
   },
   {
@@ -361,7 +361,7 @@
     "viewer2.stretch_options\n",
     "viewer2.stretch = 'sqrt'\n",
     "viewer2.colormap_options\n",
-    "viewer2.set_colormap('viridis')"
+    "viewer2.set_colormap('Viridis')"
    ]
   },
   {


### PR DESCRIPTION
Passing 'viridis' as lowercase was causing the following error in the notebook:

`ValueError: Invalid colormap 'viridis', must be one of ['Gray', 'Viridis', 'Plasma', 'Inferno', 'Magma', 'Purple-Blue', 'Yellow-Green-Blue', 'Yellow-Orange-Red', 'Red-Purple', 'Blue-Green', 'Hot', 'Red-Blue', 'Red-Yellow-Blue', 'Purple-Orange', 'Purple-Green', 'Reversed: Gray', 'Reversed: Viridis', 'Reversed: Plasma', 'Reversed: Inferno', 'Reversed: Magma', 'Reversed: Hot']`
