### PR TITLE
update index to render recent notebooks

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -49,6 +49,11 @@ location of the notebooks for you to :ref:`download <install>`.
        - **Data:**
        - **Tools:** mast, astroquery
        - **Cross-instrument:** All.
+   * - `RGB images with Imviz <https://github.com/spacetelescope/jdat_notebooks/tree/main/notebooks/rgb_imviz>`_
+     - - **Use case:** create RGB images using Imviz programmatically.
+       - **Data:** Carina Nebula, NIRCam observations
+       - **Tools:** jdaviz
+       - **Cross-instrument:** Any imager.
    * - `Specviz GUI <https://github.com/spacetelescope/jdat_notebooks/tree/main/notebooks/specviz_notebookGUI_interaction>`_
      - - **Use case:** How to inspect and export spectra in Specviz GUI.
        - **Data:** NIRISS simulation generated with MIRAGE.
@@ -152,6 +157,11 @@ location of the notebooks for you to :ref:`download <install>`.
        - **Data:** Simulated NIRSpec MOS data; point sources.
        - **Tools:** jwst pipeline
        - **Cross-instrument:**
+   * - `MOS Spectroscopy of Extragalactic Field <https://github.com/spacetelescope/jdat_notebooks/tree/main/notebooks/mos_spectroscopy_advanced>`_
+     - - **Use case:** emission-line measurements and template matching on 1D spectra.
+       - **Data:** CEERS NIRSpec observations.
+       - **Tools:** specutils, astropy, matplotlib, jdaviz
+       - **Cross-instrument:**  
    * - `BOTS Transiting Exoplanet <https://github.com/spacetelescope/jdat_notebooks/tree/main/notebooks/transit_spectroscopy_notebook>`_
      - - **Use case:** Primary transit of an exoplanet.
        - **Data:** Simulated NIRSpec data from ground-based campaign.


### PR DESCRIPTION
This PR adds the following notebooks to the index page:
- RGB images with Imviz
- MOS Spectroscopy of Extragalactic Field
<img width="815" alt="image" src="https://user-images.githubusercontent.com/66814693/231307255-df92a79c-e1b1-407e-b12a-1ce690187509.png">
<img width="890" alt="image" src="https://user-images.githubusercontent.com/66814693/231307453-bd89e338-6803-4913-9de9-3fd1330d2055.png">

