### PR TITLE
Update parameter retrieval label after Jdaviz change

### DIFF
--- a/notebooks/IFU_cube_continuum_fit/NGC4151_FeII_ContinuumFit.ipynb
+++ b/notebooks/IFU_cube_continuum_fit/NGC4151_FeII_ContinuumFit.ipynb
@@ -630,10 +630,14 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "params['LinFitCont_3d']['slope']"
+    "# If you are using jdaviz < 3.5, uncomment the following line instead:\n",
+    "# params['LinFitCont_3d']['slope']\n",
+    "params['LinFitCont']['slope']"
    ]
   },
   {
@@ -865,15 +869,19 @@
     "# Overwrite gauss model with only 2 of the components of interest\n",
     "gauss_cube_2component = gauss_cube*0\n",
     "\n",
+    "model_label = \"GaussAll\"\n",
+    "# If you are using jdaviz < 3.5, uncomment the following line instead:\n",
+    "# model_label = \"GaussAll_3d\"\n",
+    "\n",
     "nz, ny, nx = gauss_cube_2component.shape\n",
     "for i in range(0, nx-1):\n",
     "    for j in range(0, ny-1):\n",
-    "        amp1 = params['GaussAll_3d']['amplitude_0'][i][j]\n",
-    "        amp2 = params['GaussAll_3d']['amplitude_2'][i][j]\n",
-    "        m1 = params['GaussAll_3d']['mean_0'][i][j]\n",
-    "        m2 = params['GaussAll_3d']['mean_2'][i][j]\n",
-    "        stdev1 = params['GaussAll_3d']['stddev_0'][i][j]\n",
-    "        stdev2 = params['GaussAll_3d']['stddev_2'][i][j]\n",
+    "        amp1 = params[model_label]['amplitude_0'][i][j]\n",
+    "        amp2 = params[model_label]['amplitude_2'][i][j]\n",
+    "        m1 = params[model_label]['mean_0'][i][j]\n",
+    "        m2 = params[model_label]['mean_2'][i][j]\n",
+    "        stdev1 = params[model_label]['stddev_0'][i][j]\n",
+    "        stdev2 = params[model_label]['stddev_2'][i][j]\n",
     "        g1 = models.Gaussian1D(amplitude=amp1*u.Unit('count'), mean=m1*u.m, stddev=stdev1*u.m)\n",
     "        g2 = models.Gaussian1D(amplitude=amp2*u.Unit('count'), mean=m2*u.m, stddev=stdev2*u.m)\n",
     "        gauss_cube_2component[:, i, j] = g1(all_spec.spectral_axis)+g2(all_spec.spectral_axis)"
@@ -983,7 +991,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -997,7 +1005,20 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.7.15"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": false,
+   "sideBar": false,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": false,
+   "toc_window_display": false
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
https://github.com/spacetelescope/jdaviz/pull/2171 updated the dictionary keys for cube fit model parameters retrieved with `cubeviz.get_model_parameters()`. This update to this notebook will be needed after Jdaviz 3.5 is released.