### PR TITLE
add redshift notebook to home

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -127,3 +127,5 @@ parts:
       title: MOS Spectroscopy of Extragalactic Field
     - file: notebooks/transit_spectroscopy_notebook/Exoplanet_Transmission_Spectra_JWST.ipynb
       title: BOTS Time Series Observations
+    - file: notebooks/galaxy_redshift/redshift_fitting.ipynb
+      title: Redshift and Template Fitting

--- a/index.rst
+++ b/index.rst
@@ -167,7 +167,11 @@ location of the notebooks for you to :ref:`download <install>`.
        - **Data:** Simulated NIRSpec data from ground-based campaign.
        - **Tools:**
        - **Cross-instrument:**
-
+   * - `Redshift and Template Fitting <https://github.com/spacetelescope/jdat_notebooks/tree/main/notebooks/galaxy_redshift>`_
+     - - **Use case:** Measure the redshift of a galaxy from its spectrum using 2 different methods.
+       - **Data:** JWST/NIRSpec spectrum from program 2736.
+       - **Tools:**  jdaviz, specutils.
+       - **Cross-instrument:** NIRISS, NIRCam.
 Help
 ====
 


### PR DESCRIPTION
This PR adds the Redshift notebook to the homepage and lists it under the NIRSPec category. 

<img width="1040" alt="Notebooks" src="https://github.com/spacetelescope/jdat_notebooks/assets/66814693/8f705263-8910-4bbd-81a4-b07af456316e">
<img width="846" alt="Pasted Graphic 2" src="https://github.com/spacetelescope/jdat_notebooks/assets/66814693/fe184f5e-645f-4ec2-a71f-e9e2a278c63e">
