### PR TITLE
Address dependency issues in the aperture phot nb

### DIFF
--- a/notebooks/aperture_photometry/NIRCam_Aperture_Photometry_Example.ipynb
+++ b/notebooks/aperture_photometry/NIRCam_Aperture_Photometry_Example.ipynb
@@ -60,7 +60,7 @@
     "\n",
     "from photutils.detection import DAOStarFinder\n",
     "from photutils.background import MMMBackground, MADStdBackgroundRMS, Background2D\n",
-    "from photutils import CircularAperture, CircularAnnulus, aperture_photometry"
+    "from photutils.aperture import CircularAperture, CircularAnnulus, aperture_photometry"
    ]
   },
   {
@@ -161,7 +161,7 @@
     "    else:\n",
     "        d = d\n",
     "\n",
-    "    wv = np.float(f[1:3])\n",
+    "    wv = float(f[1:3])\n",
     "\n",
     "    if wv > 24:\n",
     "        ff_long.append(f)\n",
@@ -448,7 +448,7 @@
     "\n",
     "    for rad in radius:\n",
     "        print(\"Performing aperture photometry for filter {1}; radius r = {0} px\".format(rad, filt))\n",
-    "        rr = np.str(rad)\n",
+    "        rr = str(rad)\n",
     "        aperture = CircularAperture(positions, r=rad)\n",
     "        annulus_aperture = CircularAnnulus(positions, r_in=sky_in, r_out=sky_out)\n",
     "        annulus_mask = annulus_aperture.to_mask(method='center')\n",
@@ -526,7 +526,7 @@
     "    for j, filt in enumerate(filts_short):\n",
     "        for i in np.arange(0, len(dict_images[det][filt]['images']), 1):\n",
     "\n",
-    "            radius = np.str(radii[j])\n",
+    "            radius = str(radii[j])\n",
     "\n",
     "            image = fits.open(dict_images[det][filt]['images'][0])\n",
     "            data = image[1].data\n",
@@ -1435,7 +1435,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/aperture_photometry/requirements.txt
+++ b/notebooks/aperture_photometry/requirements.txt
@@ -1,6 +1,6 @@
-numpy==1.19.1
-pandas==1.1.1
-jwst@git+https://github.com/spacetelescope/jwst.git@0.16.1
-astropy==4.0.1.post1
-photutils==1.0.1
-matplotlib==3.3.1
+numpy==1.25.2
+pandas==2.1.0
+jwst==1.11.4
+astropy==5.3.3
+photutils==1.9.0
+matplotlib==3.7.2


### PR DESCRIPTION
The aperture photometry/NIRCam_Aperture_Photometry notebook's dependencies have been updated, and the issues related to the dependencies that caused execution failure in the notebooks have been fixed in this pull request. All tests run locally with Python 3.11