### PR TITLE
Address dependency issues on spectral ext nb

### DIFF
--- a/notebooks/optimal_extraction_dynamic/Spectral_Extraction.ipynb
+++ b/notebooks/optimal_extraction_dynamic/Spectral_Extraction.ipynb
@@ -87,10 +87,11 @@
    },
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib inline\n",
     "from glob import glob\n",
     "import numpy as np\n",
-    "from jwst.datamodels import ImageModel, MultiSpecModel\n",
+    "from stdatamodels.jwst.datamodels import ImageModel\n",
+    "from stdatamodels.jwst.datamodels import MultiSpecModel\n",
     "from astropy.io import fits\n",
     "from astropy.modeling import models, fitting\n",
     "from astropy.visualization import astropy_mpl_style, simple_norm\n",
@@ -1424,8 +1425,8 @@
     "    # assume that WebbPSF data files have not been downloaded\n",
     "    import tarfile, sys\n",
     "    print(\"Downloading WebbPSF data files.\")\n",
-    "    webb_url = \"https://stsci.box.com/shared/static/qcptcokkbx7fgi3c00w2732yezkxzb99.gz\"\n",
-    "    webb_file = os.path.join('.', \"webbpsf-data-0.9.0.tar.gz\")\n",
+    "    webb_url = \"https://stsci.box.com/shared/static/qxpiaxsjwo15ml6m4pkhtk36c9jgj70k.gz\"\n",
+    "    webb_file = os.path.join('.', \"webbpsf-data-1.2.1.tar.gz\")\n",
     "    urllib.request.urlretrieve(webb_url, webb_file)\n",
     "    print(\"Extracting into ./webbpsf-data ...\")\n",
     "    tar = tarfile.open(webb_file)\n",
@@ -1749,7 +1750,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1763,7 +1764,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/optimal_extraction_dynamic/requirements.txt
+++ b/notebooks/optimal_extraction_dynamic/requirements.txt
@@ -1,5 +1,7 @@
-astropy == 5.1
+astropy == 5.3.3
 scipy >= 1.8.1
-ipywidgets >= 7.7.0
-jwst >= 1.5.2
-webbpsf >= 1.0.1
+ipywidgets >= 8.0.0
+jwst >= 1.11.4
+webbpsf >= 1.2.1
+stdatamodels==1.7.2
+specutils==1.11.0


### PR DESCRIPTION
The aperture optimal_extraction_dynamic/Spectral_Extraction.ipynb notebook's dependencies have been updated, and the issues related to the dependencies that caused execution failure in the notebooks have been fixed in this pull request. All tests run locally with Python 3.11