### PR TITLE
Address dependency issues on transit spectrosc nb

### DIFF
--- a/notebooks/transit_spectroscopy_notebook/Exoplanet_Transmission_Spectra_JWST.ipynb
+++ b/notebooks/transit_spectroscopy_notebook/Exoplanet_Transmission_Spectra_JWST.ipynb
@@ -293,13 +293,13 @@
     "plt.cmap = plt.cm.magma\n",
     "plt.cmap.set_bad('k',1.)\n",
     "plt.rcParams['image.cmap'] = 'magma'                   # Colormap.\n",
-    "plt.rcParams['image.interpolation'] = None\n",
+    "plt.rcParams['image.interpolation'] = 'none'\n",
     "plt.rcParams['image.origin'] = 'lower'\n",
     "plt.rcParams['font.family'] = \"monospace\"\n",
     "plt.rcParams['font.monospace'] = 'DejaVu Sans Mono'\n",
     "\n",
     "img=all_spec[:,:,expnum]\n",
-    "zeros=np.where(img <= 0)     #Plot on a log scale, so set zero or negitive values to a small number \n",
+    "zeros=np.where(img <= 0)     #Plot on a log scale, so set zero or negative values to a small number \n",
     "img[zeros]=1E-10\n",
     "fig,axs = plt.subplots()\n",
     "f=axs.imshow(np.log10(img),vmin=0) #Plot image\n",
@@ -357,7 +357,7 @@
     "plt.cmap = plt.cm.magma\n",
     "plt.cmap.set_bad('k',1.)\n",
     "plt.rcParams['image.cmap'] = 'magma'                   # Colormap.\n",
-    "plt.rcParams['image.interpolation'] = None\n",
+    "plt.rcParams['image.interpolation'] = 'none'\n",
     "plt.rcParams['image.origin'] = 'lower'\n",
     "plt.rcParams['font.family'] = \"monospace\"\n",
     "plt.rcParams['font.monospace'] = 'DejaVu Sans Mono'\n",
@@ -1696,7 +1696,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/transit_spectroscopy_notebook/requirements.txt
+++ b/notebooks/transit_spectroscopy_notebook/requirements.txt
@@ -1,8 +1,8 @@
-lmfit==1.0.0
-scikit-learn==0.22.1
-numpy==1.18.1
-scipy==1.4.1
-joblib==0.14.1
-matplotlib==3.3.1
-astropy==4.0.1.post1
-pandas==1.1.2
+lmfit==1.2.2
+scikit-learn==1.3.0
+numpy==1.25.2
+scipy==1.11.2
+joblib==1.3.2
+matplotlib==3.7.3
+astropy==5.3.3
+pandas==2.1.0


### PR DESCRIPTION
The aperture transit_spectroscopy_notebook/Exoplanet_Transmission_Spectra_JWST.ipynb notebook's dependencies have been updated, and the issues related to the dependencies that caused execution failure in the notebooks have been fixed in this pull request. All tests run locally with Python 3.11