### PR TITLE
Update notebooks to remove deprecated methods

### DIFF
--- a/notebooks/IFU_cube_continuum_fit/NGC4151_FeII_ContinuumFit.ipynb
+++ b/notebooks/IFU_cube_continuum_fit/NGC4151_FeII_ContinuumFit.ipynb
@@ -224,7 +224,7 @@
    "outputs": [],
    "source": [
     "cubeviz = Cubeviz()\n",
-    "cubeviz.app"
+    "cubeviz.show()"
    ]
   },
   {
@@ -234,7 +234,7 @@
    "outputs": [],
    "source": [
     "# Here, we load the data into the Cubeviz app.\n",
-    "cubeviz.load_data(fn) "
+    "cubeviz.load_data(fn)"
    ]
   },
   {
@@ -339,7 +339,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Retrieve the spectrum (Subset1) of the user-defined region from the Spectrum Viewer as a Spectrum1D object."
+    "Retrieve the spectra of the user-defined regions from the Spectrum Viewer as a Spectrum1D object."
    ]
   },
   {
@@ -349,9 +349,9 @@
    "outputs": [],
    "source": [
     "# Extract spectra corresponding to the colored regions in cubeviz\n",
-    "spectrum1 = cubeviz.app.get_data_from_viewer('spectrum-viewer', 'Subset 1') # AGN Center\n",
-    "spectrum2 = cubeviz.app.get_data_from_viewer('spectrum-viewer', 'Subset 2') # Red shifted component\n",
-    "spectrum3 = cubeviz.app.get_data_from_viewer('spectrum-viewer', 'Subset 3') # Blue shifted component\n",
+    "spectrum1 = cubeviz.get_data(\"contents[SCI]\", spatial_subset='Subset 1', function=\"mean\") # AGN Center\n",
+    "spectrum2 = cubeviz.get_data(\"contents[SCI]\", spatial_subset='Subset 2', function=\"mean\") # Red shifted component\n",
+    "spectrum3 = cubeviz.get_data(\"contents[SCI]\", spatial_subset='Subset 3', function=\"mean\") # Blue shifted component\n",
     "spectrum1"
    ]
   },
@@ -495,14 +495,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Pulling Data from Viewers\n",
+    "## Pulling other data\n",
     "\n",
-    "Note, in cubeviz, you have 4 viewers from which you can pull data.  Make sure your data are properly loaded into each viewer before executing the get_data_from_viewer command:<br />\n",
-    "\n",
-    "Top Left: flux-viewer <br />\n",
-    "Center: uncert-viewer<br />\n",
-    "Top Right: mask-viewer<br />\n",
-    "Bottom: spectrum-viewer<br />"
+    "Note, in cubeviz, you can either return the collapsed spectra as we did above by using the `function`\n",
+    "keyword argument along with (optionally) a `spatial_subset`, or return the entire data cube by omitting\n",
+    "these keywords as below."
    ]
   },
   {
@@ -511,9 +508,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# List data from viewer\n",
-    "regions = cubeviz.app.get_data_from_viewer(\"uncert-viewer\")\n",
-    "regions"
+    "# List available data\n",
+    "print(cubeviz.app.data_collection)"
    ]
   },
   {
@@ -523,7 +519,7 @@
    "outputs": [],
    "source": [
     "# Extract continuum model from Cubeviz above\n",
-    "cont_psf_cube = cubeviz.app.get_data_from_viewer(\"uncert-viewer\", \"LinFitCont [Cube] 1\")"
+    "cont_psf_cube = cubeviz.get_data(\"LinFitCont [Cube] 1\")"
    ]
   },
   {
@@ -636,7 +632,7 @@
    "source": [
     "# Open up a new instance of Cubeviz to visualize continuum subtracted data\n",
     "cubeviz2 = Cubeviz()\n",
-    "cubeviz2.app"
+    "cubeviz2.show()"
    ]
   },
   {
@@ -646,7 +642,7 @@
    "outputs": [],
    "source": [
     "cont_sub_cube = 'NGC4151_Hband_ContinuumSubtract.fits'\n",
-    "cubeviz2.app.load_data(cont_sub_cube, data_label='Continuum Subtracted')"
+    "cubeviz2.load_data(cont_sub_cube, data_label='Continuum Subtracted')"
    ]
   },
   {
@@ -737,7 +733,7 @@
    "outputs": [],
    "source": [
     "# List spectra available in spectrum-viewer\n",
-    "spec = cubeviz2.app.get_data_from_viewer('spectrum-viewer') \n",
+    "spec = cubeviz2.specviz.get_spectra()\n",
     "spec"
    ]
   },
@@ -748,9 +744,9 @@
    "outputs": [],
    "source": [
     "# Get gauss model spectrum and model cube\n",
-    "all_spec = cubeviz2.app.get_data_from_viewer('spectrum-viewer', 'Continuum Subtracted[SCI]') # AGN Center Data Cube\n",
-    "gauss_spec = cubeviz2.app.get_data_from_viewer('spectrum-viewer', 'GaussAll') # AGN Center Model Spec\n",
-    "gauss_cube = cubeviz2.app.get_data_from_viewer(\"uncert-viewer\", \"GaussAll [Cube] 1\") # AGN Center Model Cube"
+    "all_spec = cubeviz2.get_data('Continuum Subtracted[SCI]', function='mean') # AGN Center Data Cube\n",
+    "gauss_spec = cubeviz2.get_data('GaussAll', function='mean') # AGN Center Model Spec\n",
+    "gauss_cube = cubeviz2.get_data('GaussAll [Cube] 1') # AGN Center Model Cube"
    ]
   },
   {
@@ -963,7 +959,7 @@
    "source": [
     "# Open up a new instance of Cubeviz to visualize continuum subtracted data\n",
     "cubeviz3 = Cubeviz()\n",
-    "cubeviz3.app"
+    "cubeviz3.show()"
    ]
   },
   {
@@ -973,7 +969,7 @@
    "outputs": [],
    "source": [
     "cont_sub_cube = 'NGC4151_Hband_FinalSubtract.fits'\n",
-    "cubeviz3.app.load_data(cont_sub_cube, data_label='Red/Blue Shift')"
+    "cubeviz3.load_data(cont_sub_cube, data_label='Red/Blue Shift')"
    ]
   }
  ],
@@ -993,7 +989,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.5"
   },
   "toc": {
    "base_numbering": 1,

--- a/notebooks/MRS_Mstar_analysis/JWST_Mstar_dataAnalysis_analysis.ipynb
+++ b/notebooks/MRS_Mstar_analysis/JWST_Mstar_dataAnalysis_analysis.ipynb
@@ -84,6 +84,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     },
@@ -288,9 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Open these spectra up in Specviz\n",
@@ -312,7 +311,7 @@
    "outputs": [],
    "source": [
     "# Load in the spectrum list from above. \n",
-    "specviz.load_spectrum(splist)"
+    "specviz.load_data(splist)"
    ]
   },
   {
@@ -346,9 +345,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "cubeviz = Cubeviz()\n",
@@ -394,9 +391,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Video showing the selection of the star with a circular region of interest\n",
@@ -410,7 +405,8 @@
    "outputs": [],
    "source": [
     "# Now extract spectrum from your spectral viewer\n",
-    "spec_agb = cubeviz.app.get_data_from_viewer('spectrum-viewer', 'Subset 1') # AGB star only"
+    "spec_agb = cubeviz.get_data('combine_dithers_all_exposures_ch1-long_s3d[SCI]',\n",
+    "                            spatial_subset='Subset 1', function='mean') # AGB star only"
    ]
   },
   {
@@ -504,9 +500,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Open these spectra up in Specviz\n",
@@ -520,7 +514,7 @@
    "source": [
     "#### Developer Note: Cannot currently open a spectrum1d output from cubeviz in specviz.  https://jira.stsci.edu/browse/JDAT-1791\n",
     "\n",
-    "#specviz.load_spectrum(spec_agb)"
+    "#specviz.load_data(spec_agb)"
    ]
   },
   {
@@ -533,7 +527,7 @@
     "flux = spec_agb.flux\n",
     "wavelength = spec_agb.spectral_axis\n",
     "spec1d = Spectrum1D(spectral_axis=wavelength, flux=flux)\n",
-    "specviz.load_spectrum(spec1d)"
+    "specviz.load_data(spec1d)"
    ]
   },
   {
@@ -541,7 +535,7 @@
    "metadata": {},
    "source": [
     "# To load the entire x1d spectrum loaded earlier, you can use this command instead\n",
-    "specviz.load_spectrum(spec)"
+    "specviz.load_data(spec)"
    ]
   },
   {
@@ -598,9 +592,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Video showing how to fit a blackbody \n",
@@ -776,7 +768,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "specviz.load_spectrum(bbsub_spectra)"
+    "specviz.load_data(bbsub_spectra)"
    ]
   },
   {
@@ -842,9 +834,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Fit a local continuum between the flux densities at: 8.0 - 8.1 & 14.9 - 15.0 microns\n",
@@ -918,8 +908,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "specviz.load_spectrum(line_spec_consub, data_label='Continuum Subtraction')\n",
-    "specviz.load_spectrum(line_spec_norm, data_label='Normalized')"
+    "specviz.load_data(line_spec_consub, data_label='Continuum Subtraction')\n",
+    "specviz.load_data(line_spec_norm, data_label='Normalized')"
    ]
   },
   {
@@ -1067,7 +1057,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/ifu_optimal/ifu_optimal.ipynb
+++ b/notebooks/ifu_optimal/ifu_optimal.ipynb
@@ -148,7 +148,6 @@
     "    err = hdulist[\"ERR\"].data\n",
     "    w = wcs.WCS(hdulist[1].header)\n",
     "    hdr = hdulist[1].header\n",
-    "    hdulist.info()\n",
     "    print(w)\n",
     "\n",
     "# Window the wavelength range to focus on Hbeta-[OIII]\n",
@@ -225,13 +224,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cubeviz_data = cubeviz.app.data_collection[0]\n",
-    "\n",
-    "print(\"\\nSource Region\")\n",
     "try:\n",
-    "    region1 = cubeviz_data.get_selection_definition(\n",
-    "        \"Subset 1\", format=\"astropy-regions\"\n",
-    "    )\n",
+    "    region1 = cubeviz.get_interactive_regions()['Subset 1']\n",
     "    print(region1)\n",
     "    center_xy = [region1.center.x, region1.center.y]\n",
     "    r_pix = region1.radius\n",
@@ -297,7 +291,8 @@
     "\n",
     "print(\"\\nSource\")\n",
     "try:\n",
-    "    spectrum_subset1 = subsets[[i for i in subsets.keys() if \"Subset 1\" in i][0]]\n",
+    "    spectrum_subset1 = cubeviz.get_data(cubeviz.app.data_collection[0].label,\n",
+    "                                        spatial_subset=\"Subset 1\", function=\"mean\")\n",
     "    print(spectrum_subset1)\n",
     "except Exception:\n",
     "    print(\"There is no Subset 1 selected in the spectrum viewer.\")\n",
@@ -745,7 +740,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/ifu_optimal/ifu_optimal.ipynb
+++ b/notebooks/ifu_optimal/ifu_optimal.ipynb
@@ -225,6 +225,7 @@
    "outputs": [],
    "source": [
     "try:\n",
+    "    print(\"\\nSource Region\")\n",
     "    region1 = cubeviz.get_interactive_regions()['Subset 1']\n",
     "    print(region1)\n",
     "    center_xy = [region1.center.x, region1.center.y]\n",
@@ -740,7 +741,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Recent Jdaviz releases have deprecated (and finally removed)  the `app.get_data_from_viewer`, `app.get_subsets_from_viewer`, and `specviz.load_spectrum` methods. This PR updates affected notebooks accordingly. I tagged a few relevant folks as reviewers, wasn't sure who all would want to see this.