### PR TITLE
add "dollarmath" to _config.yml to enable math expressions in notebooks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,6 +36,7 @@ parse:
     # don't forget to list any other extensions you want enabled,
     # including those that are enabled by default!
     - html_image
+    - dollarmath
     
 # Add a bibtex file so that we can create citations
 #bibtex_bibfiles:


### PR DESCRIPTION
**Relevant Tickets**
- [SPB-1856](https://jira.stsci.edu/browse/SPB-1856)

**Summary**
- Previously, mathematical expressions embedded in dollar signs were not being rendered properly in HTML.
- See [introduction section of notebook _BOTS Time Series Observations_](https://spacetelescope.github.io/jdat_notebooks/notebooks/transit_spectroscopy_notebook/Exoplanet_Transmission_Spectra_JWST.html#introduction) for an example.
- After some searching a solution was found in [documentation](https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#dollar-delimited-math).
- The _config.yml file was updated to fix the issue.  