### PR TITLE
Create weekly_html_accessibility_check.yml

### DIFF
--- a/.github/workflows/weekly_html_accessibility_check.yml
+++ b/.github/workflows/weekly_html_accessibility_check.yml
@@ -1,0 +1,13 @@
+name: Weekly HTML Accessibility Check
+on:
+  schedule:
+    - cron: '0 4 * * 0' # 0400 UTC every Sunday
+  workflow_dispatch:
+
+jobs:
+  Scheduled:
+   uses: spacetelescope/notebook-ci-actions/.github/workflows/html_accessibility_check.yml@main
+   with:
+     target_url: https://spacetelescope.github.io/${{ github.event.repository.name }}/intro.html
+   secrets:
+     A11YWATCH_TOKEN: ${{ secrets.A11YWATCH_TOKEN }}


### PR DESCRIPTION
- Copied over [weekly_html_accessibility_check.yml ](https://github.com/spacetelescope/hst_notebooks/blob/main/.github/workflows/weekly_html_accessibility_check.yml) from hst_notebooks to perform [A11yWatch](https://a11ywatch.com/) html accessibility scans on [mast_notebooks](https://spacetelescope.github.io/mast_notebooks/) webpages
- This workflow executes notebook-ci-actions workflow [html_accessibility_check.yml](https://github.com/spacetelescope/notebook-ci-actions/blob/main/.github/workflows/html_accessibility_check.yml) on a weekly cadence every Sunday at 0400 UTC.