### PR TITLE
Adding initial version of notebook for simulating NIRCam WFSS spectra

### DIFF
--- a/notebooks/NIRCam_Simulating_WFSS_Spectra/Simulating_WFSS_spectra_6June2024.ipynb
+++ b/notebooks/NIRCam_Simulating_WFSS_Spectra/Simulating_WFSS_spectra_6June2024.ipynb
@@ -1,0 +1,1148 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e779090a-5990-4f5a-aa6a-779fb45e124b",
+   "metadata": {},
+   "source": [
+    "# Techniques to Simulate WFSS Spectra"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a646f783-b72b-427c-95fa-df38ae1f41ad",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrate basic techniques to simulate WFSS dispersed spectra. The method is relatively straight-foward and relies on  using an image of a source to determine which pixels contain the source and how bright they each are. This information is then used to compute the flux of each pixel in flam units ($erg/s/cm^2/A$). The World Coordinate System (WCS) of the imaging data and WFSS observation is then used to compute the location of each pixel in the reference france of the dispersed WFSS observation. We then use the GRISMCONF functions and a wavelength vector to find where each of these wavelength segments end up being dispersed to on the WFSS observation. Since the detector pixel grid is unlikely to align with the computed coordinates in the WFSS observation, we use the Sutherland-Hodgman algorithm <a href=\"https://github.com/spacetelescope/pypolyclip\">Sutherland-Hodgman algorithm</A> to quickly compute the fraction of each projected dispersed pixel that falls on the actuall WFSS observed pixels. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "143a58d5-a1b9-4dbf-b91b-9650e72305a2",
+   "metadata": {},
+   "source": [
+    "## Pre-Requisites"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d5eec2c-9f1a-45da-b017-81ca659c4aa3",
+   "metadata": {},
+   "source": [
+    "This notebook builds on the simpler Box Extraction notebook where we introduced the general concepts of spectral extraction, as well as the use of the <A HREF=\"https://github.com/npirzkal/GRISMCONF\">GRISMCONF</A> module, which provides us with a low level interface to the calibration polynomial for WFSS modes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6dc81f70-1ab0-43d7-8b4f-07548865eb9c",
+   "metadata": {},
+   "source": [
+    "This notebook uses the GRISMCONF module and GRISMCONF NIRCam Configuration files. \n",
+    "* GRISMCONF can be obtained from <a href=\"https://github.com/npirzkal/GRISMCONF\">here</a>. It can also be installed using the command \"pip install grismconf\"\n",
+    "* NIRCam WFSS configuration files can be obtained from <a href=\"https://github.com/npirzkal/GRISM_NIRCAM\">here</a>. V9 of the configuration files were delivered to STScI in the Summer of 2023 and represent the latest version of the NIRCam WFSS Calibration as of the writing of this document. All of the files in the V9 sub-directory should be manually downloaded and stored somewhere locally, e.g. ./GRISMDATA\n",
+    "\n",
+    "In addition to the standard numpy, astropy, scipy, and matplotlib packages, this notebook also uses the ```jwst``` pipeline package, the ```pypolyclip``` package for clip polygons against a pixel grid, ```nf9```, a high level interface to SAOImageDS9 using pyds9(), and ```tqdm```, a convenience tool that returns an iterator that acts exactly like the original iterable, but prints a dynamically updating progressbar every time a value is requested. \n",
+    "\n",
+    "To install the ```jwst``` package, follow instructions here: [jwst package installation](https://github.com/spacetelescope/jwst/tree/master?tab=readme-ov-file#detailed-installation)\n",
+    "\n",
+    "To install the other packages, use ```pip```, e.g.:\n",
+    "\n",
+    "```pip install pypolyclip```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed7a9afa-af5c-4a11-9b86-f2b9afe5e53e",
+   "metadata": {},
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe0e1d7e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import requests\n",
+    "from copy import deepcopy\n",
+    "\n",
+    "import numpy as np\n",
+    "from pypolyclip import clip_multi\n",
+    "from astropy.io import fits\n",
+    "from astropy.convolution import convolve\n",
+    "from scipy.sparse import coo_matrix\n",
+    "from photutils.segmentation import make_2dgaussian_kernel\n",
+    "from photutils.segmentation import detect_sources\n",
+    "from photutils.background import Background2D, MedianBackground\n",
+    "import matplotlib.pyplot as plt\n",
+    "import tqdm\n",
+    "import grismconf\n",
+    "\n",
+    "from jwst import datamodels\n",
+    "from jwst.assign_wcs import AssignWcsStep\n",
+    "from jwst.flatfield import FlatFieldStep\n",
+    "from jwst.photom import PhotomStep"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b78896a9-4e0f-4311-a54c-163821dfe847",
+   "metadata": {},
+   "source": [
+    "## Define Functions and Parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2c30107-6afc-4b04-9a55-05db1cf3b8d1",
+   "metadata": {},
+   "source": [
+    "Define the directory containing the WFSS configuration files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fbf3822b-9ad1-408d-ab15-e52f27a2ecdc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#cPath = \"./GRISMDATA\"\n",
+    "cPath = \"/grp/jwst/wit/nircam/reference_files/specwcs/V9/V9\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1194ad74-5f93-4f99-983c-d1d7fba59177",
+   "metadata": {},
+   "source": [
+    "Define a function to download a named file via the MAST API to the current directory. The function includes authentication logic, but this example uses public data, so no MAST API token is required."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6fc3a5ef-1801-4aad-a779-a2e9e50ccadf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_jwst_file(name, mast_api_token=None, overwrite=False):\n",
+    "    \"\"\"Retrieve a JWST data file from MAST archive.\"\"\"\n",
+    "    # If the file already exists locally, don't redownload it, unless the\n",
+    "    # user has set the overwrite keyword\n",
+    "    if os.path.isfile(name):\n",
+    "        if not overwrite:\n",
+    "            print(f'{name} already exists locally. Skipping download.')\n",
+    "            return\n",
+    "        else:\n",
+    "            print(f'{name} exists locally. Re-downloading.')\n",
+    "\n",
+    "    mast_url = \"https://mast.stsci.edu/api/v0.1/Download/file\"\n",
+    "    params = dict(uri=f\"mast:JWST/product/{name}\")\n",
+    "    if mast_api_token:\n",
+    "        headers = dict(Authorization=f\"token {mast_api_token}\")\n",
+    "    else:\n",
+    "        headers = {}\n",
+    "    r = requests.get(mast_url, params=params, headers=headers, stream=True)\n",
+    "    r.raise_for_status()\n",
+    "    with open(name, \"wb\") as fobj:\n",
+    "        for chunk in r.iter_content(chunk_size=1024000):\n",
+    "            fobj.write(chunk)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e5c14ee-ee35-447f-ae72-1b92b498ac1c",
+   "metadata": {},
+   "source": [
+    "Define a function that will run the Assign WCS and Flat Field steps of the pipeline on an input rate file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "470868d0-4561-4a93-82dc-8ebba94ae0ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def run_pipeline_steps(filename):\n",
+    "    \"\"\"Run assign_wcs, followed by flat fielding\"\"\"\n",
+    "    assign_wcs = AssignWcsStep.call(filename)\n",
+    "\n",
+    "    # In order to apply the imaging mode flat field reference file to the data,\n",
+    "    # we need to trick CRDS by temporarily changing the pupil value to be CLEAR\n",
+    "    reset_pupil = False\n",
+    "    if 'GRISM' in assign_wcs.meta.instrument.pupil:\n",
+    "        true_pupil = deepcopy(assign_wcs.meta.instrument.pupil)\n",
+    "        assign_wcs.meta.instrument.pupil = 'CLEAR'\n",
+    "        reset_pupil = True\n",
+    "\n",
+    "    # Run the flat field step\n",
+    "    flat = FlatFieldStep.call(assign_wcs, save_results=True)\n",
+    "\n",
+    "    # Set the pupil back to the original value now that flat fielding is complete\n",
+    "    if reset_pupil:\n",
+    "        flat.meta.instrument.pupil = true_pupil\n",
+    "        flat.save(flat.meta.filename)\n",
+    "\n",
+    "    #Return the name of the output file, as well as the datamodel\n",
+    "    return flat.meta.filename, flat"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "208ca45f-fa4e-4e5d-8a38-e47b6d43d8b4",
+   "metadata": {},
+   "source": [
+    "## Download the Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d19d8f7-cc33-42bc-b2f2-33932ae24c9c",
+   "metadata": {},
+   "source": [
+    "We start with a simple pair of imaging and WFSS data. These were manually selected and they point at the same field on the sky using the same NIRCam module, channel, and cross filter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb987836",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First, download the imaging and WFSS files from MAST\n",
+    "imaging_file = \"jw01076109001_02102_00001_nrcalong_cal.fits\"\n",
+    "wfss_file = \"jw01076109001_02101_00001_nrcalong_rate.fits\"\n",
+    "get_jwst_file(imaging_file)\n",
+    "get_jwst_file(wfss_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5ca6e08-7704-4348-98fe-90d4e348feb4",
+   "metadata": {},
+   "source": [
+    "## Run the Assign WCS and Flat Field Steps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18cb1568-11ea-4056-8009-25b108fb846d",
+   "metadata": {},
+   "source": [
+    "Using the calibration pipeline, we run the [Assign WCS](https://jwst-pipeline.readthedocs.io/en/latest/jwst/assign_wcs/index.html) step to get the WCS object for coordinate transformations, followed by the [Flat Field](https://jwst-pipeline.readthedocs.io/en/latest/jwst/flatfield/index.html) correction for our science data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b396cf90-f324-4518-8169-cd36c89455c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wfss_flat_file, wfss_data = run_pipeline_steps(wfss_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a919a305-1c08-4681-a0b3-6b176f35c2c9",
+   "metadata": {},
+   "source": [
+    "## Load the Data into Models"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "706bc953-43ee-4e8f-a48b-3ebf30e90dda",
+   "metadata": {},
+   "source": [
+    "Read some information from the imaging data and WFSS data. We need to know which module, channel, cross filter, and grism we are looking at. We also need to find the values needed to convert the surface brightness units of the imaging cal files into units of $erg/s/cm^2/A$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3866b704-c440-4402-860d-bc1b2858def9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_model = datamodels.open(imaging_file)\n",
+    "imaging_data = image_model.data\n",
+    "\n",
+    "wfss_model = datamodels.open(wfss_flat_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f7de328a-dd2d-4125-baa9-74b39414420c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "FILTER = image_model.meta.instrument.filter\n",
+    "MODULE = image_model.meta.instrument.module\n",
+    "PUPIL = image_model.meta.instrument.pupil\n",
+    "PHOTUJA2 = image_model.meta.photometry.conversion_microjanskys\n",
+    "PIXAR_SR = image_model.meta.photometry.pixelarea_steradians\n",
+    "\n",
+    "print(f\"IMAGING FILTER: {FILTER}, MODULE: {MODULE}, PUPIL: {PUPIL}\")\n",
+    "print(f\"Pixel size: {PIXAR_SR} SR\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8ac7611-7d83-4a65-a1d2-3ed5dabc52b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "WFSS_FILTER = wfss_model.meta.instrument.filter\n",
+    "WFSS_MODULE = wfss_model.meta.instrument.module\n",
+    "WFSS_PUPIL = wfss_model.meta.instrument.pupil\n",
+    "\n",
+    "print(f\"WFSS FILTER: {FILTER}, MODULE: {MODULE}, PUPIL: {PUPIL}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b96f8a4d-8e41-489e-8b8b-30284aa96b02",
+   "metadata": {},
+   "source": [
+    "## Convert from $MJy/SR$ to $erg/s/cm^2$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ecf1fea-da1c-40df-958a-ca5a7fbe3516",
+   "metadata": {},
+   "source": [
+    "We compute the conversion between pixel values in the imaging data, which are in MJy/SR, and flam units of $erg/s/cm^2$ (per pixel). Multiplying the values in our calibrated image file by this value is what we will need to determine the flam values of each of the pixels in an object detected in our imaging data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79a3a68b-691e-4a31-8c1a-83f38eed0166",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PHOTFLAM = PIXAR_SR * 1e6 /3.3356e4/44210**2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0281bf57-a5ec-4946-96d8-13eb0d2f5201",
+   "metadata": {},
+   "source": [
+    "## Create a Segmentation Map"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f50deae4-b3e2-4b49-a86f-dbf43db9fcc6",
+   "metadata": {},
+   "source": [
+    "Since we want to disperse each of the pixels comprising a given source, we first need to get a segmentation map of all the objects. This can be done relatively easily using the ```photutils``` package."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19ef7f11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bkg_estimator = MedianBackground()\n",
+    "bkg = Background2D(imaging_data, (50, 50), filter_size=(21, 31),bkg_estimator=bkg_estimator)\n",
+    "imaging_data -= bkg.background "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f74bb26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "threshold = 50 * bkg.background_rms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c76bf196",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "kernel = make_2dgaussian_kernel(3.0, size=5)\n",
+    "convolved_data = convolve(imaging_data, kernel)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f1d9dfd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "segment_map = detect_sources(convolved_data, threshold, npixels=10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "337cecc5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(segment_map,origin=\"lower\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a91f34ea-6f65-4618-9c62-67ada10cb704",
+   "metadata": {},
+   "source": [
+    "## Simulate the Dispersion"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6928acbb-51c1-4abf-8636-91333dc542a0",
+   "metadata": {},
+   "source": [
+    "Here, we want to show how to simulate the dispersion of only one source, so we pick one. In order to simulate a full WFSS observation, what we show here needs to be done for every source in the field. Simulating all the dispersed spectra is also a way to mask out spectra when estimating the dispersed background level during subsequent extraction. It also allows you to estimate the amount of spectral contamination by overlapping spectra."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63e086ee-efd0-46ad-a371-01f2d2345ae8",
+   "metadata": {},
+   "source": [
+    "Below, we find where our sources are in the segmentation map. For this example, we manually choose a source. However, we also provide an option to choose a random source for the example. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43b1a627-72d9-4cbe-b455-87eddef295ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # find source 47\n",
+    "# find_sources = np.argwhere(segment_map.data == 47) # Indices where board == 0\n",
+    "# indices = np.ravel_multi_index([find_sources[:, 0], find_sources[:, 1]], segment_map.data.shape) \n",
+    "# ID = segment_map.data[np.unravel_index(indices[0], segment_map.data.shape)]\n",
+    "# print(f\"We picked object {ID}\")\n",
+    "\n",
+    "# # choose a random source\n",
+    "# find_sources = np.argwhere(segment_map.data != 0) # Indices where board == 0\n",
+    "# indices = np.ravel_multi_index([find_sources[:, 0], find_sources[:, 1]], segment_map.data.shape) \n",
+    "# random_source = np.random.choice(indices)\n",
+    "# ID = segment_map.data[np.unravel_index(random_source, segment_map.data.shape)]\n",
+    "# print(f\"We picked object {ID}\")\n",
+    "\n",
+    "# # choose a pixel coordinate\n",
+    "# xd,yd = 405,1465\n",
+    "xd,yd = 1575,89\n",
+    "ID = segment_map.data[yd,xd]\n",
+    "print(f\"We picked object {ID}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d711fdd-6e86-4b96-adfd-92334a535c16",
+   "metadata": {},
+   "source": [
+    "Get the pixel coordinates and their flux values (in $Mjy/SR$) for this source:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b87237f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ok = segment_map.data == ID\n",
+    "yds,xds = np.nonzero(ok)\n",
+    "cds = imaging_data[ok]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f338ef1d-2602-4f26-aa07-a156372c4506",
+   "metadata": {},
+   "source": [
+    "Check what this source looks like and plot its segmentation map in the imaging data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f249aad6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "min_x = np.min(xds)\n",
+    "max_x = np.max(xds)\n",
+    "min_y = np.min(yds)\n",
+    "max_y = np.max(yds)\n",
+    "\n",
+    "fig,axs = plt.subplots(1,2,figsize=(15,5))\n",
+    "axs[0].imshow(imaging_data[min_y:max_y,min_x:max_x],origin=\"lower\")\n",
+    "axs[1].imshow(segment_map.data[min_y:max_y,min_x:max_x],origin=\"lower\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f0b6948-e22f-431c-9bc5-1301abae73e5",
+   "metadata": {},
+   "source": [
+    "All the information we have for this source is within the reference frame of the imaging data, but we want to know where each of these pixels are in the WFSS observation, which could be at slightly different pointings. As we did when performing a basic box extraction (see the NIRCam WFSS Box Extraction notebook), this is handled using the WCS of both imaging and WFSS observations -- but this time we compute the positions of all of the pixels in the source and not simply the position of the peak of this source."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88469751-28c4-4532-8822-5bdaff3f0817",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imaging_to_world = image_model.meta.wcs.get_transform('detector','world')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "febd5bcb-f7f4-4fb0-b5d4-0a468d1ba403",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wfss_to_pix = wfss_model.meta.wcs.get_transform('world','detector')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca5e3d4f-476e-4dfb-83ed-6602552af95e",
+   "metadata": {},
+   "source": [
+    "We compute the R.A. and Dec of each of the input pixels:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2bc8e3d-ea0e-45df-9f0f-8816688d7ef7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ras,decs = imaging_to_world(xds,yds)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91cb852a-b3e7-44f0-9079-3452abe9cb0e",
+   "metadata": {},
+   "source": [
+    "We can now compute the center coordinates of the imaging pixels in the WFSS data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ca0aec5-0927-4a08-bba2-25a1311e9eb7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wavelength, order = 2.5, 0\n",
+    "xs,ys,wav,ord = wfss_to_pix(ras,decs,wavelength,order)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b012a3be-bfae-4b72-a253-5c1177baba47",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.scatter(xs,ys)\n",
+    "plt.xlabel(\"WFSS columns\")\n",
+    "plt.ylabel(\"WFSS rows\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19619a72-38da-41e6-972c-ea09fa1b42b7",
+   "metadata": {},
+   "source": [
+    "We initialize the ```grismconf``` config object. This contains the information and polynomials describing the dispersion of the disperser, as well as the corresponding inverse sensitiviy curve."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ddfcad5-eb41-4692-acfc-b12916083b8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grismconf_file = os.path.join(cPath,f\"NIRCAM_{FILTER}_mod{MODULE}_{PUPIL[-1]}.conf\")\n",
+    "print(f\"Using the grismconf file {grismconf_file}\")\n",
+    "C = grismconf.Config(os.path.join(cPath,\"NIRCAM_F444W_modA_R.conf\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26dc8950-cc75-45c1-8427-9c2e5b40c3d9",
+   "metadata": {},
+   "source": [
+    "Plot the inverse sentivity, which shows the wavelength range and shape of the sensitivity. This is defined in units of $DN/s$ per flam ($erg/s/cm^2/A$)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10891802-5e3c-46be-9d0e-b347503fbbd4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot(C.SENS_data[\"+1\"][0],C.SENS_data[\"+1\"][1])\n",
+    "plt.grid()\n",
+    "plt.xlabel(\"Wavelength (micron)\")\n",
+    "plt.ylabel(r\"DN/s per $erg/s/cm^2/A$\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e95f63d-5a27-46f6-ba16-2319f9a57c13",
+   "metadata": {},
+   "source": [
+    "When simulating this dispersed spectrum, we need to consider which wavelength of light is being dispersed, so each of the pixels above gets numerically dispersed at different discrete wavelengths. We use the ```grimconf``` configuration to quickly get the wavelength range that corresponds to the disperser and is included as the WRANGE attribute of the ```grismconf``` config object we initialized above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b4bf6bd-300a-4ab7-92cc-0a636b479e92",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wmin = C.WRANGE[\"+1\"][0]\n",
+    "wmax = C.WRANGE[\"+1\"][1]\n",
+    "\n",
+    "print(f\"The wavelength range to consider is {wmin} to {wmax}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16875987",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dlam = 0.001\n",
+    "lams = np.arange(wmin,wmax,dlam)\n",
+    "\n",
+    "print(f\"We are using {len(lams)} values of wavelengths\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1b5c887-8adb-4a12-8b47-7099f71cd2b5",
+   "metadata": {},
+   "source": [
+    "Next, we need to process each object. The following shows the process for a single pixel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d64845db-f4ee-41c0-a9d9-35d26f3b4fa9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "i = 10"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc70a326-c437-4ca2-954d-406b890d1c6e",
+   "metadata": {},
+   "source": [
+    "We start by computing the ```t``` values corresponding to the wavelengths (lams) we are considering. Refer to the Box Extraction notebook for additional background information about this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02ea112e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ts = C.INVDISPL(\"+1\",xs[i],ys[i],lams)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ada59693-4d4e-4bd9-975e-7c3956e927ea",
+   "metadata": {},
+   "source": [
+    "This computes the coordinates in the WFSS observation of the bottom left corner of our pixel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6ef5fa4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xgsA = C.DISPX(\"+1\",xs[i],ys[i],ts) + xs[i]\n",
+    "ygsA = C.DISPY(\"+1\",xs[i],ys[i],ts) + ys[i]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f729847-2f83-411b-8afb-1bdebb9db2d2",
+   "metadata": {},
+   "source": [
+    "The following three computations compute the other three corners:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4740945",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xgsB = C.DISPX(\"+1\",xs[i]+1,ys[i],ts) + xs[i]+1\n",
+    "ygsB = C.DISPY(\"+1\",xs[i]+1,ys[i],ts) + ys[i]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b59e1d1c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xgsC = C.DISPX(\"+1\",xs[i]+1,ys[i]+1,ts) + xs[i]+1\n",
+    "ygsC = C.DISPY(\"+1\",xs[i]+1,ys[i]+1,ts) + ys[i]+1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0b0ab3d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xgsD = C.DISPX(\"+1\",xs[i],ys[i]+1,ts) + xs[i]\n",
+    "ygsD = C.DISPY(\"+1\",xs[i],ys[i]+1,ts) + ys[i]+1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46c060d3-ab2a-4c8c-abd1-995be9910fed",
+   "metadata": {},
+   "source": [
+    "We re-organize things a little to contain a list of polygon corners which are used by the ```pypolyclip``` module to compute their overlap with the pixel coordinates of the WFSS observation. While we are looking at a single input source pixel, we are computing this at many different wavelength values so the resultant is a list of many pixels/polygons to project onto our WFSS rectilinear pixel grid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79d009b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pxs = [ [xgsA[ii],xgsB[ii],xgsC[ii],xgsD[ii]] for ii in range(len(xgsA))]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d3a1dd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pys = [ [ygsA[ii],ygsB[ii],ygsC[ii],ygsD[ii]] for ii in range(len(ygsA))]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5690d67f-1715-44ba-8b30-9a3f3641ff1c",
+   "metadata": {},
+   "source": [
+    "Checking the resulting set of dispersed pixels, we can see that everything is properly sampled. As this figure shows, the input pixel that is being dispersed, using discrete values of wavelengths, results in the dispersed pixels over all of the WFSS detector grid. It is necessary to compute and attribute the proper contribution, in $DN/s$, to each of the WFSS detector pixels. Note that we only show one of the source pixels being dispersed, while for a full object, each of the input source pixels should be similarly dispersed, resulting in multiple dispersed pixels contributing to the final counts in each of the WFSS detector pixels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "94e5dc02-7d55-42f7-90bc-f9f40fd9750a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig,ax = plt.subplots(1,1,figsize=(15,3))\n",
+    "for i in range(len(pxs)):\n",
+    "    tx = pxs[i]\n",
+    "    tx.append(pxs[i][0])\n",
+    "    ty = pys[i]\n",
+    "    ty.append(pys[i][0])\n",
+    "    plt.plot(tx,ty)\n",
+    "\n",
+    "mid = (len(pxs) - 1)/2\n",
+    "\n",
+    "plt.xticks(range(0, len(pxs)))\n",
+    "plt.xlim(pxs[int(mid)][0]-15,pxs[int(mid)][0]+15)\n",
+    "plt.xlabel(\"WFSS columns\")\n",
+    "plt.ylabel(\"WFSS Rows\")\n",
+    "plt.grid()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb5bce23-369d-4fb5-98a9-228723c4017c",
+   "metadata": {},
+   "source": [
+    "We can now use the ```pypolyclip.clip_multi``` module to compute how much each dispersed pixel (the colored boxes above) falls onto WFSS pixels (shown as the grid above)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f5793e51",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xc, yc, area, slices = clip_multi(pxs, pys, [2048,2048])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0aaad5c1-97d5-465d-a0e6-5724272ad192",
+   "metadata": {},
+   "source": [
+    "We can do this for all the pixels in this object and keep track of all the information, such as the wavelength and how much of the fraction of the original imaging pixel flux falls onto the WFSS simulated pixel array."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "800f8c58",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xcs = []\n",
+    "ycs = []\n",
+    "alams = []\n",
+    "flams = []\n",
+    "\n",
+    "all_pxs = []\n",
+    "all_pys = []\n",
+    "all_flams = []\n",
+    "all_counts = []\n",
+    "\n",
+    "# Go through all the input source pixels, in the WFSS reference frame.\n",
+    "for i in tqdm.tqdm(range(len(xs))):\n",
+    "    \n",
+    "    # We use the imaging flux in each of these pixels to compute the input DN/s\n",
+    "    counts = cds[i]\n",
+    "    flam = counts*PHOTFLAM\n",
+    "\n",
+    "    # Disperse this pixel using len(lams) wavelength. This results in len(lams) projected pixels contributing to the final WFSS data\n",
+    "    ts = C.INVDISPL(\"+1\",xs[i],ys[i],lams)\n",
+    "    xgsA = C.DISPX(\"+1\",xs[i],ys[i],ts) + xs[i]\n",
+    "    ygsA = C.DISPY(\"+1\",xs[i],ys[i],ts) + ys[i]\n",
+    "    xgsB = C.DISPX(\"+1\",xs[i]+1,ys[i],ts) + xs[i]+1\n",
+    "    ygsB = C.DISPY(\"+1\",xs[i]+1,ys[i],ts) + ys[i]\n",
+    "    xgsC = C.DISPX(\"+1\",xs[i]+1,ys[i]+1,ts) + xs[i]+1\n",
+    "    ygsC = C.DISPY(\"+1\",xs[i]+1,ys[i]+1,ts) + ys[i]+1\n",
+    "    xgsD = C.DISPX(\"+1\",xs[i],ys[i]+1,ts) + xs[i]\n",
+    "    ygsD = C.DISPY(\"+1\",xs[i],ys[i]+1,ts) + ys[i]+1\n",
+    "\n",
+    "    # Use the corners of the dispersed pixels, and compute the WFSS to which they whould contribute, and by how much\n",
+    "    pxs = [ [xgsA[ii],xgsB[ii],xgsC[ii],xgsD[ii]] for ii in range(len(xgsA))]\n",
+    "    pys = [ [ygsA[ii],ygsB[ii],ygsC[ii],ygsD[ii]] for ii in range(len(ygsA))]\n",
+    "    xc, yc, area, slices = clip_multi(pxs, pys, [2048,2048])\n",
+    "\n",
+    "    # Bookkeeping to track of the wavelength of each of the areas being projected into the WFSS pixel grid\n",
+    "    tlams = np.zeros(len(xc))\n",
+    "    for i in range(len(slices)):\n",
+    "        tlams[slices[i]] = lams[i]\n",
+    "\n",
+    "    # Store the flux, wavlength, and where they should end up on the WFSS pixel grid. Note the values in xcs and ycs are not unique\n",
+    "    xcs.extend(xc.tolist())\n",
+    "    ycs.extend(yc.tolist())\n",
+    "    flams.extend((flam*area).tolist())\n",
+    "    alams.extend(tlams.tolist())\n",
+    "\n",
+    "    # Save for plotting later. Only used for plot below.\n",
+    "    all_pxs.append(pxs)\n",
+    "    all_pys.append(pys)\n",
+    "    all_flams.append(flam)\n",
+    "    all_counts.append(flam * C.SENS[\"+1\"](tlams) * dlam * 10000 )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f765457-e7da-4c92-bc54-1efb7dfe7554",
+   "metadata": {},
+   "source": [
+    "We can attempt to display what needs to be done by plotting our projected pixels and their relative intensity on top of a simulated WFSS grid."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "249a3c5d-c7f1-4aa7-b5cb-e7426eae762b",
+   "metadata": {},
+   "source": [
+    "At this point, we have a list of WFSS pixels (xcs,ycs), the flux falling on these pixels (flams, in flam units), and the wavelength of the light contained in them (alams). In our simulation, we do not want to project flux units, but $DN/s$, so we convert the input flam valued into $DN/s$ (using the reverse relation we used in the Box Extraction notebook when we performed the inverser operation to convert extracted $DN/s$ into flam flux units)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3edd128c-3fda-44bb-9c48-2fa414bac8e2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s = C.SENS[\"+1\"](alams)\n",
+    "counts = flams * s * dlam * 10000 \n",
+    "\n",
+    "# Note: the factor of 10000 accounts for dlam being in micron while we want A since the inverse sensitivity is defined per A."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "67b1241c-4c84-4608-9b5c-9868693f3a90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"There are {len(counts)} dispersed bits of pixels to combine into a final WFSS pixel grid\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76d9941e-e949-4af3-8f0a-6066dea3f7ff",
+   "metadata": {},
+   "source": [
+    "At this point, we have a large list of $DN/s$ values and where they should be added onto our simulated WFSS observation in order to simulate the full dispersed spectrum of our source. There are duplicated entries in the xcs,ycs coordinate list as different wavelengths get mixed by the object's \"self-contamination\"."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c99799e-2afe-4fff-9d0f-86ff7d0f9e7d",
+   "metadata": {},
+   "source": [
+    "The following plot shows the dispersed input pixels, using blue outlines, projected onto the final WFSS pixels, and shaded in black proportionally to their flux."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34c89144-6321-4b99-b59f-295b3819173b",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "fig,ax = plt.subplots(1,1,figsize=(15,3))\n",
+    "for i in range(len(all_pxs)):\n",
+    "    for j in range(len(all_pxs[i])):\n",
+    "        \n",
+    "        tx = all_pxs[i][j][:]\n",
+    "        tx.append(tx[0])\n",
+    "        ty = all_pys[i][j][:]\n",
+    "        ty.append(ty[0])\n",
+    "        plt.plot(tx,ty,color='b',alpha=0.02)\n",
+    "        c = all_counts[i]\n",
+    "        c[c<0] = 0\n",
+    "        alpha_val = c[j]/c.max()/10\n",
+    "        if np.isnan(alpha_val):\n",
+    "            alpha_val=0\n",
+    "        plt.fill(tx,ty,color='k',alpha=alpha_val)\n",
+    "        \n",
+    "plt.grid()\n",
+    "plt.xticks(range(0, len(pxs)))\n",
+    "plt.xlim(pxs[int(mid)][0]-15,pxs[int(mid)][0]+15)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf6eb1dc-49e6-4d24-8d6b-745772f5a0aa",
+   "metadata": {},
+   "source": [
+    "To quickly combine all of these counts at each of their WFSS pixel locations, we can use ```scipy.coo_matrix``` which is fast and efficient:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5a67abeb-e623-4509-9eb3-a0c1c5db954a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xcs = np.array(xcs)\n",
+    "ycs = np.array(ycs)\n",
+    "\n",
+    "ok = (xcs>=0) & (xcs<2048) &  (ycs>=0) & (ycs<2048) \n",
+    "simulated = coo_matrix((counts[ok],(ycs[ok],xcs[ok])),shape=(2048,2048)).toarray()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "989d1567-6a0b-4422-8a1e-02b07e3e3029",
+   "metadata": {},
+   "source": [
+    "## Plot the Simulated Spectrum"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed4dd1c1-4416-459b-86c2-1bca5cb45d15",
+   "metadata": {},
+   "source": [
+    "Now we plot the simulated spectrum for this source."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "234196af-37b2-4e28-a0e4-d42ef9f67ecf",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "fig,ax = plt.subplots(1,1,figsize=(15,3))\n",
+    "ax.imshow(simulated, origin=\"lower\", aspect='auto',vmin=0,vmax=2)\n",
+    "ax.set_xlim(pxs[int(mid)][0]-15,pxs[int(mid)][0]+15)\n",
+    "ax.set_ylim(pys[int(mid)][0]-15,pys[int(mid)][0]+15)\n",
+    "# plt.xticks(range(0, len(pxs)));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a2e38d3-5b97-45e1-9fca-1f410529ed73",
+   "metadata": {},
+   "source": [
+    "We can compare with the real data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b320b149-e061-4033-9284-c8eb1dd33350",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig,ax = plt.subplots(1,1,figsize=(15,3))\n",
+    "ax.imshow(wfss_data.data,origin=\"lower\", aspect='auto',vmin=0,vmax=2)\n",
+    "ax.set_xlim(pxs[int(mid)][0]-15,pxs[int(mid)][0]+15)\n",
+    "ax.set_ylim(pys[int(mid)][0]-15,pys[int(mid)][0]+15)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4783d8d4-4d10-42c2-8777-c4ec4f86dcb4",
+   "metadata": {},
+   "source": [
+    "And we can plot the difference between real and simulated data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da2aa3c4-05d4-47ad-aeac-eac355ee01a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig,ax = plt.subplots(1,1,figsize=(15,3))\n",
+    "ax.imshow(wfss_data.data-simulated,origin=\"lower\", aspect='auto',vmin=0,vmax=2)\n",
+    "ax.set_xlim(pxs[int(mid)][0]-15,pxs[int(mid)][0]+15)\n",
+    "ax.set_ylim(pys[int(mid)][0]-15,pys[int(mid)][0]+15)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53cbe509",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot(np.sum(simulated,axis=-1),label=\"Simulated\")\n",
+    "plt.plot(np.nansum(wfss_data.data,axis=-1),label=\"Real\")\n",
+    "\n",
+    "max = np.max(np.sum(simulated,axis=-1))\n",
+    "min = np.min(np.sum(simulated,axis=-1))\n",
+    "plt.xlim(pys[int(mid)][0]-15,pys[int(mid)][0]+15)\n",
+    "plt.ylim(min-100,max+2000)\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d9347308-734f-4873-85cf-bf2dc8a7db94",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot(np.sum(simulated,axis=-1),label=\"Simulated\")\n",
+    "plt.plot(np.nansum(wfss_data.data,axis=-1)-700,label=\"Real\")\n",
+    "\n",
+    "max = np.max(np.sum(simulated,axis=-1))\n",
+    "min = np.min(np.sum(simulated,axis=-1))\n",
+    "plt.xlim(pys[int(mid)][0]-15,pys[int(mid)][0]+15)\n",
+    "plt.ylim(min-100,max+2000)\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9653d3c-eda0-47f8-85d4-c123048e48a8",
+   "metadata": {},
+   "source": [
+    "## About This Notebook"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bad9eabd-ad99-4a5e-8149-958f133c3fa7",
+   "metadata": {},
+   "source": [
+    "**Author**: Nor Pirzkal, ESA/AURA Level III Astronomer <br>\n",
+    "**Created On**: 2024-06-11"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This notebook checklist has been made available to us by the [the Notebooks For All team](https://github.com/Iota-School/notebooks-for-all/blob/main/resources/event-hackathon/notebook-authoring-checklist.md).
Its purpose is to serve as a guide for both the notebook author and the technical reviewer highlighting critical aspects to consider when striving to develop an accessible and effective notebook.

### The First Cell

- [x] The title of the notebook in a first-level heading (eg. `<h1>` or `# in markdown`).
- [x] A brief description of the notebook.
- [ ] A table of contents in an [ordered list](https://www.markdownguide.org/basic-syntax/#ordered-lists) (`1., 2.,` etc. in Markdown).
- [x] The author(s) and affiliation(s) (if relevant).
- [x] The date first published.
- [x] The date last edited (if relevant).
- [ ] A link to the notebook's source(s) (if relevant).

### The Rest of the Cells

- [x] There is only one H1 (`#` in Markdown) used in the notebook.
- [x] The notebook uses other [heading tags](https://www.markdownguide.org/basic-syntax/#headings) in order (meaning it does not skip numbers). 

## Text

- [x] All link text is descriptive. It tells users where they will be taken if they open the link.
- [x] All acronyms are defined at least the first time they are used. 
- [x] Field-specific/specialized terms are used when needed, but not excessively.

## Code

- [x] Code sections are introduced and explained before they appear in the notebook. This can be fulfilled with a heading in a prior Markdown cell, a sentence preceding it, or a code comment in the code section.
- [x] Code has explanatory comments (if relevant). This is most important for long sections of code.
- [x] If the author has control over the syntax highlighting theme in the notebook, that theme has enough color contrast to be legible.
- [x] Code and code explanations focus on one task at a time. Unless comparison is the point of the notebook, only one method for completing the task is described at a time.

### Images

- [ ] All images (jpg, png, svgs) have an [image description](https://www.w3.org/WAI/tutorials/images/decision-tree/). This could be
    - [ ] [Alt text](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/alt) (an `alt` property) 
    - [ ] [Empty alt text](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/alt#decorative_images) for decorative images/images meant to be skipped (an `alt` attribute with no value)
    - [ ] Captions
    - [ ] If no other options will work, the image is decribed in surrounding paragraphs.

- [ ] Any [text present in images](https://www.w3.org/WAI/WCAG21/Understanding/images-of-text.html) exists in a text form outside of the image (this can be alt text, captions, or surrounding text.)

### Visualizations

- [x] All visualizations have an image description. Review the previous section, Images, for more information on how to add it.
- [x] [Visualization descriptions](http://diagramcenter.org/specific-guidelines-e.html) include
    - [ ] The type of visualization (like bar chart, scatter plot, etc.)
    - [ ] Title
    - [ ] Axis labels and range
    - [ ] Key or legend
    - [ ] An explanation of the visualization's significance to the notebook (like the trend, an outlier in the data, what the author learned from it, etc.)

- [ ] All visualizations and their parts have [enough color contrast](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html) ([color contrast checker](https://webaim.org/resources/contrastchecker/)) to be legible. Remember that transparent colors have lower contrast than their opaque versions.
- [ ] All visualizations [convey information with more visual cues than color coding](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html). Use text labels, patterns, or icons alongside color to achieve this.
- [ ] All visualizations have an additional way for notebook readers to access the information. Linking to the original data, including a table of the data in the same notebook, or sonifying the plot are all options.