### PR TITLE
Update the python version in the installation instructions

### DIFF
--- a/install.rst
+++ b/install.rst
@@ -31,7 +31,7 @@ with most modern shells, except CSH/TCSH.
 You may want to consider installing your notebooks in a new virtual or conda environment
 to avoid version conflicts with other packages you may have installed, for example::
 
-    conda create -n jdat-nb python=3.9
+    conda create -n jdat-nb python=3.11
     conda activate jdat-nb
     git clone https://github.com/spacetelescope/jdat_notebooks.git
 


### PR DESCRIPTION
This is just a minimal PR that updates the python version that is listed in the installation instructions. Currently python 3.9 environment is created in the example. This PR updates that to python 3.11. 