### PR TITLE
MNT: Use hash for Action workflow versions and update if needed

### DIFF
--- a/.github/workflows/ci_buildondemand.yml
+++ b/.github/workflows/ci_buildondemand.yml
@@ -4,6 +4,6 @@ on:
 
 jobs:
   ExecuteNotebooks:
-   uses: spacetelescope/notebook-ci-actions/.github/workflows/ci_scheduled.yml@multi_dev
+   uses: spacetelescope/notebook-ci-actions/.github/workflows/ci_scheduled.yml@0ea14fcf22bfa36f86d7a9500003bf6454e6f2e5  # main
    with:
       python-version: ${{ vars.PYTHON_VERSION }}

--- a/.github/workflows/ci_execute_merge_generate.yml
+++ b/.github/workflows/ci_execute_merge_generate.yml
@@ -4,6 +4,6 @@ on:
 
 jobs:
   GenerateHTML:
-   uses: spacetelescope/notebook-ci-actions/.github/workflows/ci_build_merge_manual.yml@v3
+   uses: spacetelescope/notebook-ci-actions/.github/workflows/ci_build_merge_manual.yml@0ea14fcf22bfa36f86d7a9500003bf6454e6f2e5  # main
    with:
       python-version: ${{ vars.PYTHON_VERSION }}

--- a/.github/workflows/ci_execute_single.yml
+++ b/.github/workflows/ci_execute_single.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   GenerateHTML:
-   uses: spacetelescope/notebook-ci-actions/.github/workflows/ci_execute_single.yml@multi_dev
+   uses: spacetelescope/notebook-ci-actions/.github/workflows/ci_execute_single.yml@0ea14fcf22bfa36f86d7a9500003bf6454e6f2e5  # main
    with:
       python-version: ${{ vars.PYTHON_VERSION }}
       filename: ${{ github.event.inputs.filename }}

--- a/.github/workflows/ci_html_build.yml
+++ b/.github/workflows/ci_html_build.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938  # v4.2.0
         with:
           fetch-depth: 0 
           ref: ${{ github.event.pull_request.head.sha }}
@@ -38,10 +38,10 @@ jobs:
         notebook: ${{fromJson(needs.prepare_matrix.outputs.matrix)}}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938  # v4.2.0
 
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3  # v5.2.0
         with:
           python-version:  ${{ vars.PYTHON_VERSION }}
 
@@ -93,10 +93,10 @@ jobs:
       contents: write
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938  # v4.2.0
 
     - name: Set up Python  ${{ vars.PYTHON_VERSION }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3  # v5.2.0
       with:
         python-version:  ${{ vars.PYTHON_VERSION }}
         
@@ -127,7 +127,7 @@ jobs:
         
         # Push the book's HTML to github-pages
     - name: GitHub Pages action
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e  # v4.0.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./_build/html

--- a/.github/workflows/ci_manual_html_deploy.yml
+++ b/.github/workflows/ci_manual_html_deploy.yml
@@ -5,6 +5,6 @@ on:
 
 jobs:
   GenerateHTML:
-   uses: spacetelescope/notebook-ci-actions/.github/workflows/ci_builder_manual_jdat.yml@v3
+   uses: spacetelescope/notebook-ci-actions/.github/workflows/ci_builder_manual_jdat.yml@0ea14fcf22bfa36f86d7a9500003bf6454e6f2e5  # main
    with:
       python-version: ${{ vars.PYTHON_VERSION }}

--- a/.github/workflows/ci_manual_single_merge_generate.yml
+++ b/.github/workflows/ci_manual_single_merge_generate.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   GenerateHTML:
-   uses: spacetelescope/notebook-ci-actions/.github/workflows/ci_build_merge_manual_single.yml@v3
+   uses: spacetelescope/notebook-ci-actions/.github/workflows/ci_build_merge_manual_single.yml@0ea14fcf22bfa36f86d7a9500003bf6454e6f2e5  # main
    with:
       python-version: ${{ vars.PYTHON_VERSION }}
       filename: ${{ github.event.inputs.filename }}

--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   Scheduled:
-   uses: spacetelescope/notebook-ci-actions/.github/workflows/ci_scheduled.yml@v3
+   uses: spacetelescope/notebook-ci-actions/.github/workflows/ci_scheduled.yml@0ea14fcf22bfa36f86d7a9500003bf6454e6f2e5  # main
    with:
       python-version: ${{ vars.PYTHON_VERSION }}

--- a/.github/workflows/ci_runner.yml
+++ b/.github/workflows/ci_runner.yml
@@ -25,7 +25,7 @@ on:
  
 jobs:
   NotebookExecutionValidation:
-   uses: spacetelescope/notebook-ci-actions/.github/workflows/ci_runner.yml@v4
+   uses: spacetelescope/notebook-ci-actions/.github/workflows/ci_runner.yml@0ea14fcf22bfa36f86d7a9500003bf6454e6f2e5  # main
    with:
       python-version: ${{ vars.PYTHON_VERSION || '3.11' }}
    permissions:

--- a/.github/workflows/ci_security_scan.yml
+++ b/.github/workflows/ci_security_scan.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   Scheduled:
-   uses: spacetelescope/notebook-ci-actions/.github/workflows/ci_security_scan.yml@v3
+   uses: spacetelescope/notebook-ci-actions/.github/workflows/ci_security_scan.yml@0ea14fcf22bfa36f86d7a9500003bf6454e6f2e5  # main

--- a/.github/workflows/pep8_nb_style_check.yml
+++ b/.github/workflows/pep8_nb_style_check.yml
@@ -11,6 +11,6 @@ on:
 
 jobs:
   Notebook_PEP8_Check:
-   uses: spacetelescope/notebook-ci-actions/.github/workflows/notebook_pep8check.yml@v3
+   uses: spacetelescope/notebook-ci-actions/.github/workflows/notebook_pep8check.yml@0ea14fcf22bfa36f86d7a9500003bf6454e6f2e5  # main
    with:
      python-version: ${{ vars.PYTHON_VERSION || '3.11'}}

--- a/.github/workflows/pep8_script_style_check.yml
+++ b/.github/workflows/pep8_script_style_check.yml
@@ -11,6 +11,6 @@ on:
 
 jobs:
   Script_PEP8_Check:
-   uses: spacetelescope/notebook-ci-actions/.github/workflows/script_pep8check.yml@v3
+   uses: spacetelescope/notebook-ci-actions/.github/workflows/script_pep8check.yml@0ea14fcf22bfa36f86d7a9500003bf6454e6f2e5  # main
    with:
      python-version: ${{ vars.PYTHON_VERSION || '3.11' }}

--- a/.github/workflows/weekly_broken_link_finder.yml
+++ b/.github/workflows/weekly_broken_link_finder.yml
@@ -5,6 +5,6 @@ on:
 
 jobs:
   Scheduled:
-   uses: spacetelescope/notebook-ci-actions/.github/workflows/broken_link_checker.yml@v3
+   uses: spacetelescope/notebook-ci-actions/.github/workflows/broken_link_checker.yml@0ea14fcf22bfa36f86d7a9500003bf6454e6f2e5  # main
    with:
      website_url: "https://spacetelescope.github.io/jdat_notebooks/"


### PR DESCRIPTION
As recommended by https://scientific-python.org/specs/spec-0008/#pin-github-actions-release-workflows-to-their-full-release-commit-shas , this PR changes your Actions workflow version pins to hashes, and updates to latest release hashes (at the time of writing) if needed.

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.

[:ghost:](https://github.com/pllim/playpen/issues/60)