### PR TITLE
Pin jwst version for NIRSpec NSClean notebooks

### DIFF
--- a/notebooks/NIRSpec/NIRSpec_NSClean/BOTS_NSClean_example.ipynb
+++ b/notebooks/NIRSpec/NIRSpec_NSClean/BOTS_NSClean_example.ipynb
@@ -38,13 +38,25 @@
     "## 1. Introduction <a name=\"introduction\"></a>\n",
     "<hr style=\"border:1px solid black\">\n",
     "\n",
-    "The JWST NIRSpec instrument has a number of features and characteristics that observers should be aware of when planning observations and interpreting data. One notable feature seen in NIRSpec pipeline products is negative and/or surplus flux in the extracted 1-D spectrum, typically with an irregular wavelength-dependent undulation. The cause of this artifact is correlated noise, known as [1/f noise](https://jwst-docs.stsci.edu/jwst-near-infrared-spectrograph/nirspec-instrument-features-and-caveats#NIRSpecInstrumentFeaturesandCaveats-1/fnoise), from low-level detector thermal instabilities, seen as vertical banding in 2-D count rate images, particularly in exposures of the NRS2 detector. While the IRS2 readout mode reduces this effect, it is not completely eliminated.\n",
+    "The JWST NIRSpec instrument has a number of features and characteristics that observers should be aware of when planning observations and interpreting data. One notable feature seen in NIRSpec pipeline products is negative and/or surplus flux in the extracted 1-D spectrum, typically with an irregular wavelength-dependent undulation. The cause of this artifact is correlated noise, known as [1/f noise](https://jwst-docs.stsci.edu/known-issues/nirspec-known-issues#NIRSpecKnownIssues-correlatedUncorrectedcorrelatednoise-1/fnoise), from low-level detector thermal instabilities, seen as vertical banding in 2-D count rate images, particularly in exposures of the NRS2 detector. While the IRS2 readout mode reduces this effect, it is not completely eliminated.\n",
     "\n",
-    "To address this issue, the JWST Science Calibration Pipeline has integrated an external package developed by Bernard Rauscher, known as [NSClean](https://webb.nasa.gov/content/forScientists/publications.html#NSClean), within the `Spec2Pipeline` under [NSCleanStep](https://jwst-pipeline.readthedocs.io/en/latest/jwst/nsclean/main.html). This algorithm uses dark areas of the detector to fit a background model to the data in Fourier space. It requires an input mask to identify all dark areas of the detector. The more thorough and complete this mask is, the better the background fit.\n",
+    "To address this issue, the JWST Science Calibration Pipeline has integrated an external package developed by Bernard Rauscher, known as [NSClean](https://webb.nasa.gov/content/forScientists/publications.html#NSClean), within the `Spec2Pipeline` under [NSCleanStep](https://jwst-pipeline.readthedocs.io/en/1.20.2/jwst/nsclean/index.html). This algorithm uses dark areas of the detector to fit a background model to the data in Fourier space. It requires an input mask to identify all dark areas of the detector. The more thorough and complete this mask is, the better the background fit.\n",
     "\n",
-    "In this notebook, we will use the NSClean algorithm integrated into the pipeline, utilizing a mask generated on-the-fly with default parameters to remove 1/f noise. In some cases, this mask may not be complete enough/too restrictive for the best possible noise removal. To address this, we demonstrate how one can manually modify the default mask, as well as how to create an alternative mask by adjusting the [NSCleanStep parameters](https://jwst-pipeline.readthedocs.io/en/latest/jwst/nsclean/arguments.html). If needed, see the [NSClean documentation](https://iopscience.iop.org/article/10.1088/1538-3873/ad1b36/pdf) for some suggestions on manually creating a custom mask.\n",
+    "In this notebook, we will use the NSClean algorithm integrated into the pipeline, utilizing a mask generated on-the-fly with default parameters to remove 1/f noise. In some cases, this mask may not be complete enough/too restrictive for the best possible noise removal. To address this, we demonstrate how one can manually modify the default mask, as well as how to create an alternative mask by adjusting the [NSCleanStep parameters](https://jwst-pipeline.readthedocs.io/en/1.20.2/jwst/nsclean/arguments.html). If needed, see the [NSClean documentation](https://iopscience.iop.org/article/10.1088/1538-3873/ad1b36/pdf) for some suggestions on manually creating a custom mask.\n",
     "\n",
     "This notebook utilizes transit data of WASP-39b observed in the BOTS G395H grism as part of the [JWST Early Release Science program ERS-1366](https://www.stsci.edu/jwst/science-execution/approved-programs/dd-ers/program-1366) observation 3, as an example."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e14742b6-8409-438f-83e6-9daee50d8295",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<b>Warning:</b> \n",
+    "    \n",
+    "The NSClean step has been removed in JWST pipeline version 2.0.0 and replaced with the `CleanFlickerNoiseStep`, which is available in both the `Detector1Pipeline` and `Spec2Pipeline`.    The latest supported version of the JWST pipeline that includes the NSClean step is version 1.20.2.  For information on how to run the `CleanFlickerNoiseStep` for BOTS data, see the [BOTS Pipeline Notebook](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRSPEC/BOTS/JWPipeNB-NIRSpec-BOTS.ipynb).\n",
+    "</div>"
    ]
   },
   {
@@ -350,7 +362,7 @@
     "## 5. Clean up 1/f Noise with NSClean (Default Pipeline Mask) <a name=\"nsclean_default\"></a>\n",
     "<hr style=\"border:1px solid black\">\n",
     "\n",
-    "If a user-supplied mask file is not provided to the [NSClean step](https://jwst-pipeline.readthedocs.io/en/latest/jwst/nsclean/index.html) in the `Spec2Pipeline`, the pipeline will generate a mask based on default parameters. This mask will identify any pixel that is unilluminated. That is, the mask must contain True and False values, where True indicates that the pixel is dark, and False indicates that the pixel is illuminated (not dark).\n",
+    "If a user-supplied mask file is not provided to the [NSClean step](https://jwst-pipeline.readthedocs.io/en/1.20.2/jwst/nsclean/index.html) in the `Spec2Pipeline`, the pipeline will generate a mask based on default parameters. This mask will identify any pixel that is unilluminated. That is, the mask must contain True and False values, where True indicates that the pixel is dark, and False indicates that the pixel is illuminated (not dark).\n",
     "\n",
     "By default, the pipeline marks the following detector areas as illuminated, non-dark areas (False):\n",
     "\n",
@@ -1283,7 +1295,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.13"
+   "version": "3.13.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/NIRSpec/NIRSpec_NSClean/FS_NSClean_example.ipynb
+++ b/notebooks/NIRSpec/NIRSpec_NSClean/FS_NSClean_example.ipynb
@@ -39,14 +39,26 @@
     "## 1. Introduction <a name=\"introduction\"></a>\n",
     "<hr style=\"border:1px solid black\">\n",
     "\n",
-    "The JWST NIRSpec instrument has a number of features and characteristics that observers should be aware of when planning observations and interpreting data. One notable feature seen in NIRSpec pipeline products is negative and/or surplus flux in the extracted 1-D spectrum, typically with an irregular wavelength-dependent undulation. The cause of this artifact is correlated noise, known as [1/f noise](https://jwst-docs.stsci.edu/jwst-near-infrared-spectrograph/nirspec-instrument-features-and-caveats#NIRSpecInstrumentFeaturesandCaveats-1/fnoise), from low-level detector thermal instabilities, seen as vertical banding in 2-D count rate images, particularly in exposures of the NRS2 detector. While the IRS2 readout mode reduces this effect, it is not completely eliminated.\n",
+    "The JWST NIRSpec instrument has a number of features and characteristics that observers should be aware of when planning observations and interpreting data. One notable feature seen in NIRSpec pipeline products is negative and/or surplus flux in the extracted 1-D spectrum, typically with an irregular wavelength-dependent undulation. The cause of this artifact is correlated noise, known as [1/f noise](https://jwst-docs.stsci.edu/known-issues/nirspec-known-issues#NIRSpecKnownIssues-correlatedUncorrectedcorrelatednoise-1/fnoise), from low-level detector thermal instabilities, seen as vertical banding in 2-D count rate images, particularly in exposures of the NRS2 detector. While the IRS2 readout mode reduces this effect, it is not completely eliminated.\n",
     "\n",
-    "To address this issue, the JWST Science Calibration Pipeline has integrated an external package developed by Bernard Rauscher, known as [NSClean](https://webb.nasa.gov/content/forScientists/publications.html#NSClean), within the `Spec2Pipeline` under [NSCleanStep](https://jwst-pipeline.readthedocs.io/en/latest/jwst/nsclean/main.html). This algorithm uses dark areas of the detector to fit a background model to the data in Fourier space. It requires an input mask to identify all dark areas of the detector. The more thorough and complete this mask is, the better the background fit.\n",
+    "To address this issue, the JWST Science Calibration Pipeline has integrated an external package developed by Bernard Rauscher, known as [NSClean](https://webb.nasa.gov/content/forScientists/publications.html#NSClean), within the `Spec2Pipeline` under [NSCleanStep](https://jwst-pipeline.readthedocs.io/en/1.20.2/jwst/nsclean/index.html). This algorithm uses dark areas of the detector to fit a background model to the data in Fourier space. It requires an input mask to identify all dark areas of the detector. The more thorough and complete this mask is, the better the background fit.\n",
     "\n",
-    "In this notebook, we will use the NSClean algorithm integrated into the pipeline, utilizing a mask generated on-the-fly with default parameters to remove 1/f noise. In some cases, this mask may not be complete enough/too restrictive for the best possible noise removal. To address this, we demonstrate how one can manually modify the default mask, as well as how to create an alternative mask by adjusting the [NSCleanStep parameters](https://jwst-pipeline.readthedocs.io/en/latest/jwst/nsclean/arguments.html). If needed, see the [NSClean documentation](https://iopscience.iop.org/article/10.1088/1538-3873/ad1b36/pdf) for some suggestions on manually creating a custom mask.\n",
+    "In this notebook, we will use the NSClean algorithm integrated into the pipeline, utilizing a mask generated on-the-fly with default parameters to remove 1/f noise. In some cases, this mask may not be complete enough/too restrictive for the best possible noise removal. To address this, we demonstrate how one can manually modify the default mask, as well as how to create an alternative mask by adjusting the [NSCleanStep parameters](https://jwst-pipeline.readthedocs.io/en/1.20.2/jwst/nsclean/arguments.html). If needed, see the [NSClean documentation](https://iopscience.iop.org/article/10.1088/1538-3873/ad1b36/pdf) for some suggestions on manually creating a custom mask.\n",
     "\n",
     "\n",
     "This notebook provides examples from two GTO observations: a fixed slit observation of F dwarf GSC 03162-00665 from program [2757](https://www.stsci.edu/jwst/science-execution/program-information?id=2757) and an observation of the brown dwarf J03480772-6022270 from program [1189](https://www.stsci.edu/jwst/science-execution/program-information?id=1189)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aff59736-d7a7-4d35-a097-c10d07efc1ff",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<b>Warning:</b> \n",
+    "    \n",
+    "The NSClean step has been removed in JWST pipeline version 2.0.0 and replaced with the `CleanFlickerNoiseStep`, which is available in both the `Detector1Pipeline` and `Spec2Pipeline`.    The latest supported version of the JWST pipeline that includes the NSClean step is version 1.20.2.  For information on how to run the `CleanFlickerNoiseStep` for Fixed Slit data, see the [Fixed Slit Pipeline Notebook](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRSPEC/FSlit/JWPipeNB-NIRSpec-FS.ipynb).\n",
+    "</div>"
    ]
   },
   {
@@ -231,7 +243,7 @@
     "## 5. Clean up 1/f Noise with NSClean (Default Pipeline Mask) <a name=\"nsclean_default\"></a>\n",
     "<hr style=\"border:1px solid black\">\n",
     "\n",
-    "If a user-supplied mask file is not provided to the [NSClean step](https://jwst-pipeline.readthedocs.io/en/latest/jwst/nsclean/index.html) in the `Spec2Pipeline`, the pipeline will generate a mask based on default parameters. This mask will identify any pixel that is unilluminated. That is, the mask must contain True and False values, where True indicates that the pixel is dark, and False indicates that the pixel is illuminated (not dark).\n",
+    "If a user-supplied mask file is not provided to the [NSClean step](https://jwst-pipeline.readthedocs.io/en/1.20.2/jwst/nsclean/index.html) in the `Spec2Pipeline`, the pipeline will generate a mask based on default parameters. This mask will identify any pixel that is unilluminated. That is, the mask must contain True and False values, where True indicates that the pixel is dark, and False indicates that the pixel is illuminated (not dark).\n",
     "\n",
     "By default, the pipeline marks the following detector areas as illuminated, non-dark areas (False):\n",
     "\n",
@@ -1428,7 +1440,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.13"
+   "version": "3.13.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/NIRSpec/NIRSpec_NSClean/IFU_NSClean_example.ipynb
+++ b/notebooks/NIRSpec/NIRSpec_NSClean/IFU_NSClean_example.ipynb
@@ -35,13 +35,25 @@
     "## 1. Introduction <a name=\"introduction\"></a>\n",
     "<hr style=\"border:1px solid black\">\n",
     "\n",
-    "The JWST NIRSpec instrument has a number of features and characteristics that observers should be aware of when planning observations and interpreting data. One notable feature seen in NIRSpec pipeline products is negative and/or surplus flux in the extracted 1-D spectrum, typically with an irregular wavelength-dependent undulation. The cause of this artifact is correlated noise, known as [1/f noise](https://jwst-docs.stsci.edu/jwst-near-infrared-spectrograph/nirspec-instrument-features-and-caveats#NIRSpecInstrumentFeaturesandCaveats-1/fnoise), from low-level detector thermal instabilities, seen as vertical banding in 2-D count rate images, particularly in exposures of the NRS2 detector. While the IRS2 readout mode reduces this effect, it is not completely eliminated.\n",
+    "The JWST NIRSpec instrument has a number of features and characteristics that observers should be aware of when planning observations and interpreting data. One notable feature seen in NIRSpec pipeline products is negative and/or surplus flux in the extracted 1-D spectrum, typically with an irregular wavelength-dependent undulation. The cause of this artifact is correlated noise, known as [1/f noise](https://jwst-docs.stsci.edu/known-issues/nirspec-known-issues#NIRSpecKnownIssues-correlatedUncorrectedcorrelatednoise-1/fnoise), from low-level detector thermal instabilities, seen as vertical banding in 2-D count rate images, particularly in exposures of the NRS2 detector. While the IRS2 readout mode reduces this effect, it is not completely eliminated.\n",
     "\n",
-    "To address this issue, the JWST Science Calibration Pipeline has integrated an external package developed by Bernard Rauscher, known as [NSClean](https://webb.nasa.gov/content/forScientists/publications.html#NSClean), within the `Spec2Pipeline` under [NSCleanStep](https://jwst-pipeline.readthedocs.io/en/latest/jwst/nsclean/main.html). This algorithm uses dark areas of the detector to fit a background model to the data in Fourier space. It requires an input mask to identify all dark areas of the detector. The more thorough and complete this mask is, the better the background fit.\n",
+    "To address this issue, the JWST Science Calibration Pipeline has integrated an external package developed by Bernard Rauscher, known as [NSClean](https://webb.nasa.gov/content/forScientists/publications.html#NSClean), within the `Spec2Pipeline` under [NSCleanStep](https://jwst-pipeline.readthedocs.io/en/1.20.2/jwst/nsclean/index.html). This algorithm uses dark areas of the detector to fit a background model to the data in Fourier space. It requires an input mask to identify all dark areas of the detector. The more thorough and complete this mask is, the better the background fit.\n",
     "\n",
-    "In this notebook, we will use the NSClean algorithm integrated into the pipeline, utilizing a mask generated on-the-fly with default parameters to remove 1/f noise. In some cases, this mask may not be complete enough/too restrictive for the best possible noise removal. To address this, we demonstrate how one can manually modify the default mask, as well as how to create an alternative mask by adjusting the [NSCleanStep parameters](https://jwst-pipeline.readthedocs.io/en/latest/jwst/nsclean/arguments.html). If needed, see the [NSClean documentation](https://iopscience.iop.org/article/10.1088/1538-3873/ad1b36/pdf) for some suggestions on manually creating a custom mask.\n",
+    "In this notebook, we will use the NSClean algorithm integrated into the pipeline, utilizing a mask generated on-the-fly with default parameters to remove 1/f noise. In some cases, this mask may not be complete enough/too restrictive for the best possible noise removal. To address this, we demonstrate how one can manually modify the default mask, as well as how to create an alternative mask by adjusting the [NSCleanStep parameters](https://jwst-pipeline.readthedocs.io/en/1.20.2/jwst/nsclean/arguments.html). If needed, see the [NSClean documentation](https://iopscience.iop.org/article/10.1088/1538-3873/ad1b36/pdf) for some suggestions on manually creating a custom mask.\n",
     "\n",
     "This notebook utilizes IFU observation of quasar XID2028 with grating/filter G140H/F100LP as part of [JWST Early Release Science program ERS-1335](https://www.stsci.edu/jwst/science-execution/approved-programs/dd-ers/program-1335) observation 4, as an example. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "086d9f1b-d105-41e6-a135-88c745b893f8",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<b>Warning:</b> \n",
+    "    \n",
+    "The NSClean step has been removed in JWST pipeline version 2.0.0 and replaced with the `CleanFlickerNoiseStep`, which is available in both the `Detector1Pipeline` and `Spec2Pipeline`.    The latest supported version of the JWST pipeline that includes the NSClean step is version 1.20.2.  For information on how to run the `CleanFlickerNoiseStep` for IFU data, see the [IFU Pipeline Notebook](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRSPEC/IFU/JWPipeNB-NIRSpec-IFU.ipynb).\n",
+    "</div>"
    ]
   },
   {
@@ -215,7 +227,7 @@
     "## 5. Clean up 1/f Noise with NSClean (Default Pipeline Mask) <a name=\"nsclean_default\"></a>\n",
     "<hr style=\"border:1px solid black\">\n",
     "\n",
-    "If a user-supplied mask file is not provided to the [NSClean step](https://jwst-pipeline.readthedocs.io/en/latest/jwst/nsclean/index.html) in the `Spec2Pipeline`, the pipeline will generate a mask based on default parameters. This mask will identify any pixel that is unilluminated. That is, the mask must contain True and False values, where True indicates that the pixel is dark, and False indicates that the pixel is illuminated (not dark).\n",
+    "If a user-supplied mask file is not provided to the [NSClean step](https://jwst-pipeline.readthedocs.io/en/1.20.2/jwst/nsclean/index.html) in the `Spec2Pipeline`, the pipeline will generate a mask based on default parameters. This mask will identify any pixel that is unilluminated. That is, the mask must contain True and False values, where True indicates that the pixel is dark, and False indicates that the pixel is illuminated (not dark).\n",
     "\n",
     "By default, the pipeline marks the following detector areas as illuminated, non-dark areas (False):\n",
     "\n",
@@ -974,7 +986,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.13"
+   "version": "3.13.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/NIRSpec/NIRSpec_NSClean/MOS_NSClean_example.ipynb
+++ b/notebooks/NIRSpec/NIRSpec_NSClean/MOS_NSClean_example.ipynb
@@ -35,13 +35,25 @@
     "## 1. Introduction <a name=\"introduction\"></a>\n",
     "<hr style=\"border:1px solid black\">\n",
     "\n",
-    "The JWST NIRSpec instrument has a number of features and characteristics that observers should be aware of when planning observations and interpreting data. One notable feature seen in NIRSpec pipeline products is negative and/or surplus flux in the extracted 1-D spectrum, typically with an irregular wavelength-dependent undulation. The cause of this artifact is correlated noise, known as [1/f noise](https://jwst-docs.stsci.edu/jwst-near-infrared-spectrograph/nirspec-instrument-features-and-caveats#NIRSpecInstrumentFeaturesandCaveats-1/fnoise), from low-level detector thermal instabilities, seen as vertical banding in 2-D count rate images, particularly in exposures of the NRS2 detector. While the IRS2 readout mode reduces this effect, it is not completely eliminated.\n",
+    "The JWST NIRSpec instrument has a number of features and characteristics that observers should be aware of when planning observations and interpreting data. One notable feature seen in NIRSpec pipeline products is negative and/or surplus flux in the extracted 1-D spectrum, typically with an irregular wavelength-dependent undulation. The cause of this artifact is correlated noise, known as [1/f noise](https://jwst-docs.stsci.edu/known-issues/nirspec-known-issues#NIRSpecKnownIssues-correlatedUncorrectedcorrelatednoise-1/fnoise), from low-level detector thermal instabilities, seen as vertical banding in 2-D count rate images, particularly in exposures of the NRS2 detector. While the IRS2 readout mode reduces this effect, it is not completely eliminated.\n",
     "\n",
-    "To address this issue, the JWST Science Calibration Pipeline has integrated an external package developed by Bernard Rauscher, known as [NSClean](https://webb.nasa.gov/content/forScientists/publications.html#NSClean), within the `Spec2Pipeline` under [NSCleanStep](https://jwst-pipeline.readthedocs.io/en/latest/jwst/nsclean/main.html). This algorithm uses dark areas of the detector to fit a background model to the data in Fourier space. It requires an input mask to identify all dark areas of the detector. The more thorough and complete this mask is, the better the background fit.\n",
+    "To address this issue, the JWST Science Calibration Pipeline has integrated an external package developed by Bernard Rauscher, known as [NSClean](https://webb.nasa.gov/content/forScientists/publications.html#NSClean), within the `Spec2Pipeline` under [NSCleanStep](https://jwst-pipeline.readthedocs.io/en/1.20.2/jwst/nsclean/index.html). This algorithm uses dark areas of the detector to fit a background model to the data in Fourier space. It requires an input mask to identify all dark areas of the detector. The more thorough and complete this mask is, the better the background fit.\n",
     "\n",
-    "In this notebook, we will use the NSClean algorithm integrated into the pipeline, utilizing a mask generated on-the-fly with default parameters to remove 1/f noise. In some cases, this mask may not be complete enough/too restrictive for the best possible noise removal. To address this, we demonstrate how one can manually modify the default mask, as well as how to create an alternative mask by adjusting the [NSCleanStep parameters](https://jwst-pipeline.readthedocs.io/en/latest/jwst/nsclean/arguments.html). If needed, see the [NSClean documentation](https://iopscience.iop.org/article/10.1088/1538-3873/ad1b36/pdf) for some suggestions on manually creating a custom mask.\n",
+    "In this notebook, we will use the NSClean algorithm integrated into the pipeline, utilizing a mask generated on-the-fly with default parameters to remove 1/f noise. In some cases, this mask may not be complete enough/too restrictive for the best possible noise removal. To address this, we demonstrate how one can manually modify the default mask, as well as how to create an alternative mask by adjusting the [NSCleanStep parameters](https://jwst-pipeline.readthedocs.io/en/1.20.2/jwst/nsclean/arguments.html). If needed, see the [NSClean documentation](https://iopscience.iop.org/article/10.1088/1538-3873/ad1b36/pdf) for some suggestions on manually creating a custom mask.\n",
     "\n",
     "This notebook utilizes a MOS observation from the CEERS program with grating/filter G395M/F290LP, which is part of the [JWST Early Release Science program ERS-1345](https://www.stsci.edu/jwst/science-execution/approved-programs/dd-ers/program-1345) observation 61, as an example."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4e84652-ed93-4318-a750-66b13b07d562",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<b>Warning:</b> \n",
+    "    \n",
+    "The NSClean step has been removed in JWST pipeline version 2.0.0 and replaced with the `CleanFlickerNoiseStep`, which is available in both the `Detector1Pipeline` and `Spec2Pipeline`.    The latest supported version of the JWST pipeline that includes the NSClean step is version 1.20.2.  For information on how to run the `CleanFlickerNoiseStep` for MOS data, see the [MOS Pipeline Notebook](https://github.com/spacetelescope/jwst-pipeline-notebooks/blob/main/notebooks/NIRSPEC/MOS/JWPipeNB-NIRSpec-MOS.ipynb).\n",
+    "</div>"
    ]
   },
   {
@@ -230,7 +242,7 @@
     "## 5. Clean up 1/f Noise with NSClean (Default Pipeline Mask) <a name=\"nsclean_default\"></a>\n",
     "<hr style=\"border:1px solid black\">\n",
     "\n",
-    "If a user-supplied mask file is not provided to the [NSClean step](https://jwst-pipeline.readthedocs.io/en/latest/jwst/nsclean/index.html) in the `Spec2Pipeline`, the pipeline will generate a mask based on default parameters. This mask will identify any pixel that is unilluminated. That is, the mask must contain True and False values, where True indicates that the pixel is dark, and False indicates that the pixel is illuminated (not dark).\n",
+    "If a user-supplied mask file is not provided to the [NSClean step](https://jwst-pipeline.readthedocs.io/en/1.20.2/jwst/nsclean/index.html) in the `Spec2Pipeline`, the pipeline will generate a mask based on default parameters. This mask will identify any pixel that is unilluminated. That is, the mask must contain True and False values, where True indicates that the pixel is dark, and False indicates that the pixel is illuminated (not dark).\n",
     "\n",
     "By default, the pipeline marks the following detector areas as illuminated, non-dark areas (False):\n",
     "\n",
@@ -1063,7 +1075,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.13"
+   "version": "3.13.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/NIRSpec/NIRSpec_NSClean/requirements.txt
+++ b/notebooks/NIRSpec/NIRSpec_NSClean/requirements.txt
@@ -1,6 +1,6 @@
 numpy >= 1.25.2
 requests >= 2.32.4
-jwst >= 1.14.0
+jwst >= 1.14.0, <= 1.20.2
 crds >= 11.17.19
 stpipe >= 0.5.2
 matplotlib >= 3.8.4


### PR DESCRIPTION
This PR pins the JWST pipeline version for the NIRSpec NSClean notebooks to <=1.20.2 and adds a warning to the notebooks noting that jwst 2.0.0 removes the NSClean step and replaces it with the clean_flicker_noise step.  I've also updated some of the text links to point to old JWST ReadTheDocs pages where information about the NSClean step can still be found, and replaced a couple other broken links.

More comprehensive updates of these notebooks will be made in the future for compatibility with newer JWST pipeline versions.

This notebook checklist has been made available to us by the [the Notebooks For All team](https://github.com/Iota-School/notebooks-for-all/blob/main/resources/event-hackathon/notebook-authoring-checklist.md).
Its purpose is to serve as a guide for both the notebook author and the technical reviewer highlighting critical aspects to consider when striving to develop an accessible and effective notebook.

### The First Cell

- [ ] The title of the notebook in a first-level heading (eg. `<h1>` or `# in markdown`).
- [ ] A brief description of the notebook.
- [ ] A table of contents in an [ordered list](https://www.markdownguide.org/basic-syntax/#ordered-lists) (`1., 2.,` etc. in Markdown).
- [ ] The author(s) and affiliation(s) (if relevant).
- [ ] The date first published.
- [ ] The date last edited (if relevant).
- [ ] A link to the notebook's source(s) (if relevant).

### The Rest of the Cells

- [ ] There is only one H1 (`#` in Markdown) used in the notebook.
- [ ] The notebook uses other [heading tags](https://www.markdownguide.org/basic-syntax/#headings) in order (meaning it does not skip numbers). 

## Text

- [ ] All link text is descriptive. It tells users where they will be taken if they open the link.
- [ ] All acronyms are defined at least the first time they are used. 
- [ ] Field-specific/specialized terms are used when needed, but not excessively.

## Code

- [ ] Code sections are introduced and explained before they appear in the notebook. This can be fulfilled with a heading in a prior Markdown cell, a sentence preceding it, or a code comment in the code section.
- [ ] Code has explanatory comments (if relevant). This is most important for long sections of code.
- [ ] If the author has control over the syntax highlighting theme in the notebook, that theme has enough color contrast to be legible.
- [ ] Code and code explanations focus on one task at a time. Unless comparison is the point of the notebook, only one method for completing the task is described at a time.

### Images

- [ ] All images (jpg, png, svgs) have an [image description](https://www.w3.org/WAI/tutorials/images/decision-tree/). This could be
    - [ ] [Alt text](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/alt) (an `alt` property) 
    - [ ] [Empty alt text](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/alt#decorative_images) for decorative images/images meant to be skipped (an `alt` attribute with no value)
    - [ ] Captions
    - [ ] If no other options will work, the image is decribed in surrounding paragraphs.

- [ ] Any [text present in images](https://www.w3.org/WAI/WCAG21/Understanding/images-of-text.html) exists in a text form outside of the image (this can be alt text, captions, or surrounding text.)

### Visualizations

- [ ] All visualizations have an image description. Review the previous section, Images, for more information on how to add it.
- [ ] [Visualization descriptions](http://diagramcenter.org/specific-guidelines-e.html) include
    - [ ] The type of visualization (like bar chart, scatter plot, etc.)
    - [ ] Title
    - [ ] Axis labels and range
    - [ ] Key or legend
    - [ ] An explanation of the visualization's significance to the notebook (like the trend, an outlier in the data, what the author learned from it, etc.)

- [ ] All visualizations and their parts have [enough color contrast](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html) ([color contrast checker](https://webaim.org/resources/contrastchecker/)) to be legible. Remember that transparent colors have lower contrast than their opaque versions.
- [ ] All visualizations [convey information with more visual cues than color coding](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html). Use text labels, patterns, or icons alongside color to achieve this.
- [ ] All visualizations have an additional way for notebook readers to access the information. Linking to the original data, including a table of the data in the same notebook, or sonifying the plot are all options.